### PR TITLE
Use tool_calls instead of functions

### DIFF
--- a/custom_components/extended_openai_conversation/const.py
+++ b/custom_components/extended_openai_conversation/const.py
@@ -18,7 +18,7 @@ entity_id,name,state,aliases
 ```
 
 The current state of devices is provided in available devices.
-Use execute_services function only for requested action, not for current states.
+Use the execute_service function only for requested action, not for current states.
 Do not execute service without user's confirmation.
 Do not restate or appreciate what user says, rather make a quick inquiry.
 """
@@ -36,43 +36,35 @@ CONF_FUNCTIONS = "functions"
 DEFAULT_CONF_FUNCTIONS = [
     {
         "spec": {
-            "name": "execute_services",
-            "description": "Use this function to execute service of devices in Home Assistant.",
+            "name": "execute_service",
+            "description": "Use this function to execute a service of devices in Home Assistant.",
             "parameters": {
                 "type": "object",
                 "properties": {
-                    "list": {
-                        "type": "array",
-                        "items": {
-                            "type": "object",
-                            "properties": {
-                                "domain": {
-                                    "type": "string",
-                                    "description": "The domain of the service",
-                                },
-                                "service": {
-                                    "type": "string",
-                                    "description": "The service to be called",
-                                },
-                                "service_data": {
-                                    "type": "object",
-                                    "description": "The service data object to indicate what to control.",
-                                    "properties": {
-                                        "entity_id": {
-                                            "type": "string",
-                                            "description": "The entity_id retrieved from available devices. It must start with domain, followed by dot character.",
-                                        }
-                                    },
-                                    "required": ["entity_id"],
-                                },
-                            },
-                            "required": ["domain", "service", "service_data"],
+                    "domain": {
+                        "type": "string",
+                        "description": "The domain of the service",
+                    },
+                    "service": {
+                        "type": "string",
+                        "description": "The service to be called",
+                    },
+                    "service_data": {
+                        "type": "object",
+                        "description": "The service data object to indicate what to control.",
+                        "properties": {
+                            "entity_id": {
+                                "type": "string",
+                                "description": "The entity_id retrieved from available devices. It must start with domain, followed by dot character.",
+                            }
                         },
-                    }
+                        "required": ["entity_id"],
+                    },
                 },
+                "required": ["domain", "service", "service_data"],
             },
         },
-        "function": {"type": "native", "name": "execute_service"},
+        "function": {"type": "native", "name": "execute_service_single"},
     }
 ]
 CONF_BASE_URL = "base_url"

--- a/custom_components/extended_openai_conversation/helpers.py
+++ b/custom_components/extended_openai_conversation/helpers.py
@@ -3,6 +3,8 @@ import logging
 import os
 import yaml
 import time
+import voluptuous
+import json
 from bs4 import BeautifulSoup
 from typing import Any
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
@@ -146,13 +148,13 @@ class NativeFunctionExecutor(FunctionExecutor):
     ) -> str:
         name = function["name"]
         if name == "execute_service":
-            return await self.execute_service(
+            return json.dumps(await self.execute_service(
                 hass, function, arguments, user_input, exposed_entities
-            )
+            ))
         if name == "execute_service_single":
-            return await self.execute_service_single(
+            return json.dumps(await self.execute_service_single(
                 hass, function, arguments, user_input, exposed_entities
-            )
+            ))
         if name == "add_automation":
             return await self.add_automation(
                 hass, function, arguments, user_input, exposed_entities
@@ -195,10 +197,10 @@ class NativeFunctionExecutor(FunctionExecutor):
                 service=service,
                 service_data=service_data,
             )
-            return True
-        except HomeAssistantError:
+            return {'success': True}
+        except (HomeAssistantError, voluptuous.Error) as e:
             _LOGGER.error(e)
-            return False
+            return {'error': str(e)}
 
     async def execute_service(
         self,


### PR DESCRIPTION
Function calls are deprecated, "tools" are now recommended. It's basically the same thing, but allows multiple tool calls in a single message.

This now changes the default function to take a single service as argument - preferring to split it into multiple separate tool calls instead. The old form is still supported for existing templates.

I've found tool calls have way less issues with repeating the same call multiple times. This may have been related to the messages previously not including the correct sequence of function_call, function output, but I didn't confirm (tool calls are more strict in requiring exact request -> response sequences).

Additionally, I've changed the output to handle additional validation errors, and return the error text to OpenAI.

I also ran into some cases where a single input message resulted in multiple outputs. Something like this:
1. User: Please do X
2. Assistant: tool_call X1
3. Tool: Invalid call
4. Assistant: Let me try again; tool_call X2
5. Assistant: I did X

I have not been able to reproduce the above consistently, but the output for multiple messages would now be returned to the user if it does happen, instead of leaving gaps in the conversation.

See:
 * https://platform.openai.com/docs/api-reference/chat/create#chat-create-tools
 * https://platform.openai.com/docs/guides/function-calling/parallel-function-calling