### PR TITLE
feat: Attach the user's name to the user message payload if known

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Derived from [OpenAI Conversation](https://www.home-assistant.io/integrations/op
 - Ability to call service of Home Assistant
 - Ability to create automation
 - Ability to get data from API or web page
+- Option to pass the current user's name to OpenAI via the user message context
 
 ## How it works
 Extended OpenAI Conversation uses OpenAI API's feature of [function calling](https://platform.openai.com/docs/guides/function-calling) to call service of Home Assistant.
@@ -55,6 +56,7 @@ https://github.com/jekalmin/extended_openai_conversation/assets/2917984/64ba656e
 By clicking a button from Edit Assist, Options can be customized.<br/>
 Options include [OpenAI Conversation](https://www.home-assistant.io/integrations/openai_conversation/) options and two new options. 
 
+- `Attach Username`: Pass the active user's name (if applicaple) to OpenAI via rhe message payload. Currently, this only applies to conversations through the UI or REST API.
 
 - `Maximum Function Calls Per Conversation`: limit the number of function calls in a single conversation.
 (Sometimes function is called over and over again, possibly running into infinite loop) 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ https://github.com/jekalmin/extended_openai_conversation/assets/2917984/64ba656e
 By clicking a button from Edit Assist, Options can be customized.<br/>
 Options include [OpenAI Conversation](https://www.home-assistant.io/integrations/openai_conversation/) options and two new options. 
 
-- `Attach Username`: Pass the active user's name (if applicaple) to OpenAI via rhe message payload. Currently, this only applies to conversations through the UI or REST API.
+- `Attach Username`: Pass the active user's name (if applicable) to OpenAI via the message payload. Currently, this only applies to conversations through the UI or REST API.
 
 - `Maximum Function Calls Per Conversation`: limit the number of function calls in a single conversation.
 (Sometimes function is called over and over again, possibly running into infinite loop) 

--- a/custom_components/extended_openai_conversation/__init__.py
+++ b/custom_components/extended_openai_conversation/__init__.py
@@ -11,7 +11,7 @@ from openai import error
 
 from homeassistant.components import conversation
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_API_KEY, MATCH_ALL
+from homeassistant.const import CONF_API_KEY, MATCH_ALL, ATTR_NAME
 from homeassistant.core import HomeAssistant, ServiceCall, SupportsResponse
 from homeassistant.util import ulid
 from homeassistant.components.homeassistant.exposed_entities import async_should_expose
@@ -150,8 +150,12 @@ class OpenAIAgent(conversation.AbstractConversationAgent):
                     response=intent_response, conversation_id=conversation_id
                 )
             messages = [{"role": "system", "content": prompt}]
+        user_message = {"role": "user", "content": user_input.text}
+        user = await self.hass.auth.async_get_user(user_input.context.user_id)
+        if user is not None and user.name is not None:
+            user_message[ATTR_NAME] = user.name
 
-        messages.append({"role": "user", "content": user_input.text})
+        messages.append(user_message)
 
         try:
             response = await self.query(user_input, messages, exposed_entities, 0)

--- a/custom_components/extended_openai_conversation/__init__.py
+++ b/custom_components/extended_openai_conversation/__init__.py
@@ -30,6 +30,7 @@ from homeassistant.helpers import (
 )
 
 from .const import (
+    CONF_ATTACH_USERNAME,
     CONF_CHAT_MODEL,
     CONF_MAX_TOKENS,
     CONF_PROMPT,
@@ -38,6 +39,7 @@ from .const import (
     CONF_MAX_FUNCTION_CALLS_PER_CONVERSATION,
     CONF_FUNCTIONS,
     CONF_BASE_URL,
+    DEFAULT_ATTACH_USERNAME,
     DEFAULT_CHAT_MODEL,
     DEFAULT_MAX_TOKENS,
     DEFAULT_PROMPT,
@@ -151,9 +153,10 @@ class OpenAIAgent(conversation.AbstractConversationAgent):
                 )
             messages = [{"role": "system", "content": prompt}]
         user_message = {"role": "user", "content": user_input.text}
-        user = await self.hass.auth.async_get_user(user_input.context.user_id)
-        if user is not None and user.name is not None:
-            user_message[ATTR_NAME] = user.name
+        if self.entry.options.get(CONF_ATTACH_USERNAME, DEFAULT_ATTACH_USERNAME):
+            user = await self.hass.auth.async_get_user(user_input.context.user_id)
+            if user is not None and user.name is not None:
+                user_message[ATTR_NAME] = user.name
 
         messages.append(user_message)
 

--- a/custom_components/extended_openai_conversation/config_flow.py
+++ b/custom_components/extended_openai_conversation/config_flow.py
@@ -201,7 +201,7 @@ def openai_config_option_schema(options: MappingProxyType[str, Any]) -> dict:
         vol.Optional(
             CONF_ATTACH_USERNAME,
             description={
-                "suggested_value": options[CONF_ATTACH_USERNAME]
+                "suggested_value": options.get(CONF_ATTACH_USERNAME)
             },
             default=DEFAULT_ATTACH_USERNAME,
         ): BooleanSelector(),

--- a/custom_components/extended_openai_conversation/config_flow.py
+++ b/custom_components/extended_openai_conversation/config_flow.py
@@ -15,6 +15,7 @@ from homeassistant.const import CONF_NAME, CONF_API_KEY
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.selector import (
+    BooleanSelector,
     NumberSelector,
     NumberSelectorConfig,
     TemplateSelector,
@@ -24,6 +25,7 @@ from homeassistant.helpers.selector import (
 from .helpers import validate_authentication
 
 from .const import (
+    CONF_ATTACH_USERNAME,
     CONF_CHAT_MODEL,
     CONF_MAX_TOKENS,
     CONF_PROMPT,
@@ -32,6 +34,7 @@ from .const import (
     CONF_MAX_FUNCTION_CALLS_PER_CONVERSATION,
     CONF_FUNCTIONS,
     CONF_BASE_URL,
+    DEFAULT_ATTACH_USERNAME,
     DEFAULT_CHAT_MODEL,
     DEFAULT_MAX_TOKENS,
     DEFAULT_PROMPT,
@@ -65,6 +68,7 @@ DEFAULT_OPTIONS = types.MappingProxyType(
         CONF_TOP_P: DEFAULT_TOP_P,
         CONF_TEMPERATURE: DEFAULT_TEMPERATURE,
         CONF_FUNCTIONS: DEFAULT_CONF_FUNCTIONS_STR,
+        CONF_ATTACH_USERNAME: DEFAULT_ATTACH_USERNAME,
     }
 )
 
@@ -194,4 +198,11 @@ def openai_config_option_schema(options: MappingProxyType[str, Any]) -> dict:
             description={"suggested_value": options.get(CONF_FUNCTIONS)},
             default=DEFAULT_CONF_FUNCTIONS_STR,
         ): TemplateSelector(),
+        vol.Optional(
+            CONF_ATTACH_USERNAME,
+            description={
+                "suggested_value": options[CONF_ATTACH_USERNAME]
+            },
+            default=DEFAULT_ATTACH_USERNAME,
+        ): BooleanSelector(),
     }

--- a/custom_components/extended_openai_conversation/const.py
+++ b/custom_components/extended_openai_conversation/const.py
@@ -77,3 +77,5 @@ DEFAULT_CONF_FUNCTIONS = [
 ]
 CONF_BASE_URL = "base_url"
 DEFAULT_CONF_BASE_URL = "https://api.openai.com/v1"
+CONF_ATTACH_USERNAME = "attach_username"
+DEFAULT_ATTACH_USERNAME = False

--- a/custom_components/extended_openai_conversation/strings.json
+++ b/custom_components/extended_openai_conversation/strings.json
@@ -25,7 +25,8 @@
           "temperature": "Temperature",
           "top_p": "Top P",
           "max_function_calls_per_conversation": "Maximum function calls per conversation",
-          "functions": "Functions"
+          "functions": "Functions",
+          "attach_username": "Attach Username to Message"
         }
       }
     }

--- a/custom_components/extended_openai_conversation/translations/en.json
+++ b/custom_components/extended_openai_conversation/translations/en.json
@@ -25,7 +25,8 @@
                     "temperature": "Temperature",
                     "top_p": "Top P",
                     "max_function_calls_per_conversation": "Maximum function calls per conversation",
-                    "functions": "Functions"
+                    "functions": "Functions",
+                    "attach_username": "Attach Username to Message"
                 }
             }
         }

--- a/custom_components/extended_openai_conversation/translations/ko.json
+++ b/custom_components/extended_openai_conversation/translations/ko.json
@@ -25,7 +25,8 @@
                     "temperature": "Temperature",
                     "top_p": "Top P",
                     "max_function_calls_per_conversation": "Maximum function calls per conversation",
-                    "functions": "Functions"
+                    "functions": "Functions",
+                    "attach_username": "Attach Username to Message"
                 }
             }
         }


### PR DESCRIPTION
# Motivation

I wanted my assistant to know who it was talking to.

# Approach

If there is a user_id attached to the context that is provided via `user_input`, retrieve the name of the user from HASS's authentication manager. This primarily applies when interacting with the UI or invoking the process service from a user context.

# Future Work

## Wake Words
Add voice recognition to wake word detection to differentiate the user who started the conversation

## Full Feature
Add voice recognition to differentiate the user who is currently speaking - allowing for multiple participate in a conversation