### PR TITLE
[#49] add OpenAIError log

### DIFF
--- a/custom_components/extended_openai_conversation/__init__.py
+++ b/custom_components/extended_openai_conversation/__init__.py
@@ -166,6 +166,7 @@ class OpenAIAgent(conversation.AbstractConversationAgent):
         try:
             response = await self.query(user_input, messages, exposed_entities, 0)
         except error.OpenAIError as err:
+            _LOGGER.error(err)
             intent_response = intent.IntentResponse(language=user_input.language)
             intent_response.async_set_error(
                 intent.IntentResponseErrorCode.UNKNOWN,


### PR DESCRIPTION
## Issue
- https://github.com/jekalmin/extended_openai_conversation/issues/49

## Objective
- If OpenAIError occurs, the error message is not only responded but also logged.