### PR TITLE
[#57] make functions optional

### DIFF
--- a/custom_components/extended_openai_conversation/__init__.py
+++ b/custom_components/extended_openai_conversation/__init__.py
@@ -284,6 +284,9 @@ class OpenAIAgent(conversation.AbstractConversationAgent):
             DEFAULT_MAX_FUNCTION_CALLS_PER_CONVERSATION,
         ):
             function_call = "none"
+        if len(functions) == 0:
+            functions = None
+            function_call = None
 
         model_key = self.entry.options.get(
             CONF_MODEL_KEY, get_default_model_key(api_base)


### PR DESCRIPTION
## Objective
- make `functions` optional

## Options
- By setting `Functions` to `[]` like below, it will not pass `functions` parameter to openai
<img width="576" alt="스크린샷 2023-12-24 오후 10 49 41" src="https://github.com/jekalmin/extended_openai_conversation/assets/2917984/0f4dbae1-07a5-4153-87e3-739593c5d3cb">
