### PR TITLE
removed deprecated function in calendar

### DIFF
--- a/examples/function/calendar/README.md
+++ b/examples/function/calendar/README.md
@@ -22,7 +22,7 @@
   function:
     type: script
     sequence:
-    - service: calendar.list_events
+    - service: calendar.get_events
       data:
         start_date_time: "{{start_date_time}}"
         end_date_time: "{{end_date_time}}"


### PR DESCRIPTION
 fixes #88 by removing a deprecated function call with the new call. Tested on my local installation.