### PR TITLE
[#86] "area_id" and "deviced_id" can be set to execute_service

### DIFF
--- a/custom_components/extended_openai_conversation/__init__.py
+++ b/custom_components/extended_openai_conversation/__init__.py
@@ -24,7 +24,6 @@ from homeassistant.exceptions import (
     ConfigEntryNotReady,
     HomeAssistantError,
     TemplateError,
-    ServiceNotFound,
 )
 
 from homeassistant.helpers import (
@@ -59,26 +58,13 @@ from .const import (
 )
 
 from .exceptions import (
-    EntityNotFound,
-    EntityNotExposed,
-    CallServiceError,
     FunctionNotFound,
-    NativeNotFound,
     FunctionLoadFailed,
     ParseArgumentsFailed,
     InvalidFunction,
 )
 
 from .helpers import (
-    FUNCTION_EXECUTORS,
-    FunctionExecutor,
-    NativeFunctionExecutor,
-    ScriptFunctionExecutor,
-    TemplateFunctionExecutor,
-    RestFunctionExecutor,
-    ScrapeFunctionExecutor,
-    CompositeFunctionExecutor,
-    convert_to_template,
     validate_authentication,
     get_function_executor,
     is_azure,
@@ -88,11 +74,11 @@ from .helpers import (
 _LOGGER = logging.getLogger(__name__)
 
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
-AZURE_DOMAIN_PATTERN = r"\.openai\.azure\.com"
 
 
 # hass.data key for agent.
 DATA_AGENT = "agent"
+
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -306,7 +292,7 @@ class OpenAIAgent(conversation.AbstractConversationAgent):
         )
 
 
-        _LOGGER.info("Response %s", response)
+        _LOGGER.info("Response %s", response.model_dump(exclude_none=True))
         choice: Choice = response.choices[0]
         message = choice.message
         if choice.finish_reason == "function_call":

--- a/custom_components/extended_openai_conversation/exceptions.py
+++ b/custom_components/extended_openai_conversation/exceptions.py
@@ -35,7 +35,7 @@ class CallServiceError(HomeAssistantError):
         """Initialize error."""
         super().__init__(
             self,
-            f"unable to call service {domain}.{service} with data {data}. 'entity_id' is required",
+            f"unable to call service {domain}.{service} with data {data}. One of 'entity_id', 'area_id', or 'device_id' is required",
         )
         self.domain = domain
         self.service = service
@@ -43,7 +43,7 @@ class CallServiceError(HomeAssistantError):
 
     def __str__(self) -> str:
         """Return string representation."""
-        return f"unable to call service {self.domain}.{self.service} with data {self.data}. 'entity_id' is required"
+        return f"unable to call service {self.domain}.{self.service} with data {self.data}. One of 'entity_id', 'area_id', or 'device_id' is required"
 
 
 class FunctionNotFound(HomeAssistantError):


### PR DESCRIPTION
#86

## Objective
- Add `area_id` and `device_id` to `execute_services` function
- One of following is required to call `execute_services`
  - `entity_id`
  - `area_id`
  - `device_id`

## Example
#### Prompt
``````yaml
Areas:
```yaml
{%- for area in areas() %}
- {{area}}
{%- endfor %}
```
``````

#### Functions
```yaml
- spec:
    name: execute_services
    description: Use this function to execute service of devices in Home Assistant.
    parameters:
      type: object
      properties:
        list:
          type: array
          items:
            type: object
            properties:
              domain:
                type: string
                description: The domain of the service
              service:
                type: string
                description: The service to be called
              service_data:
                type: object
                description: The service data object to indicate what to control.
                properties:
                  entity_id:
                    type: array
                    items:
                      type: string
                      description: The entity_id retrieved from available devices. It must start with domain, followed by dot character.
                  area_id:
                    type: array
                    items:
                      type: string
                      description: The id retrieved from areas. You can specify only area_id without entity_id to act on all entities in that area
            required:
            - domain
            - service
            - service_data
  function:
    type: native
    name: execute_service
```