### PR TITLE
Add area awareness

### DIFF
--- a/custom_components/extended_openai_conversation/__init__.py
+++ b/custom_components/extended_openai_conversation/__init__.py
@@ -169,7 +169,9 @@ class OpenAIAgent(conversation.AbstractConversationAgent):
             conversation_id = ulid.ulid()
             user_input.conversation_id = conversation_id
             try:
-                prompt = self._async_generate_prompt(raw_prompt, exposed_entities)
+                prompt = self._async_generate_prompt(
+                    raw_prompt, exposed_entities, user_input
+                )
             except TemplateError as err:
                 _LOGGER.error("Error rendering prompt: %s", err)
                 intent_response = intent.IntentResponse(language=user_input.language)
@@ -221,12 +223,18 @@ class OpenAIAgent(conversation.AbstractConversationAgent):
             response=intent_response, conversation_id=conversation_id
         )
 
-    def _async_generate_prompt(self, raw_prompt: str, exposed_entities) -> str:
+    def _async_generate_prompt(
+        self,
+        raw_prompt: str,
+        exposed_entities,
+        user_input: conversation.ConversationInput,
+    ) -> str:
         """Generate a prompt for the user."""
         return template.Template(raw_prompt, self.hass).async_render(
             {
                 "ha_name": self.hass.config.location_name,
                 "exposed_entities": exposed_entities,
+                "current_device_id": user_input.device_id,
             },
             parse_result=False,
         )


### PR DESCRIPTION
## Objective
Area awareness feature in [Year of Voice Chapter 5](https://www.home-assistant.io/blog/2023/12/13/year-of-the-voice-chapter-5/#area-awareness) 

## Changes
- Added "current_device_id" variable in prompt.

## How to use
1. Assign area to your ESP-S3-BOX or Atom echo.
2. Copy and paste prompt below.
3. Ask "turn on light", "turn off light"

#### Prompt
``````
I want you to act as smart home manager of Home Assistant.
I will provide information of smart home along with a question, you will truthfully make correction or answer using information provided in one sentence in everyday language.

Current Time: {{now()}}
Current Area: {{area_id(current_device_id)}}

Available Devices:
```csv
entity_id,name,state,area_id,aliases
{% for entity in exposed_entities -%}
{{ entity.entity_id }},{{ entity.name }},{{ entity.state }},{{area_id(entity.entity_id)}},{{entity.aliases | join('/')}}
{% endfor -%}
```

Areas:
```csv
area_id,name
{% for area_id in areas() -%}
{{area_id}},{{area_name(area_id)}}
{% endfor -%}
```

The current state of devices is provided in available devices.
Use execute_services function only for requested action, not for current states.
Do not execute service without user's confirmation.
Do not restate or appreciate what user says, rather make a quick inquiry.
Make decisions based on current area first.
``````