### PR TITLE
[#105] fire "extended_openai_conversation.conversation.finished" event

### DIFF
--- a/custom_components/extended_openai_conversation/const.py
+++ b/custom_components/extended_openai_conversation/const.py
@@ -10,6 +10,7 @@ CONF_SKIP_AUTHENTICATION = "skip_authentication"
 DEFAULT_SKIP_AUTHENTICATION = False
 
 EVENT_AUTOMATION_REGISTERED = "automation_registered_via_extended_openai_conversation"
+EVENT_CONVERSATION_FINISHED = "extended_openai_conversation.conversation.finished"
 
 CONF_PROMPT = "prompt"
 DEFAULT_PROMPT = """I want you to act as smart home manager of Home Assistant.


### PR DESCRIPTION
## Objective
- Enable users to track token usage, message history, etc...

## Usage
- `data.response.usage.total_tokens`: Total tokens
- `data.messages`: Message history of current context
- `data.user_input.conversation_id`: Current context id
- `data.user_input.device_id`: Device id

## Automation Example
#### 1. Total tokens
```yaml
trigger:
  - platform: event
    event_type: extended_openai_conversation.conversation.finished
condition: []
action:
  - service: input_number.set_value
    target:
      entity_id: input_number.YOUR_ENTITY_ID
    data:
      value: "{{trigger.event.data.response.usage.total_tokens}}"
```

## Event
### extended_openai_conversation.conversation.finished
#### devtools
<img width="800" alt="스크린샷 2024-02-09 오후 7 11 29" src="https://github.com/jekalmin/extended_openai_conversation/assets/2917984/03861d9f-a356-4e72-812d-de6fa540d18a">

#### yaml

```yaml
event_type: extended_openai_conversation.conversation.finished
data:
  response:
    id: chatcmpl-8l3km5sMmk3IhAgACol3zxEqZX9dy
    choices:
      - finish_reason: stop
        index: 0
        message:
          content: The living room light has been turned on.
          role: assistant
          function_call: null
          tool_calls: null
        logprobs: null
    created: 1707473480
    model: gpt-3.5-turbo-0125
    object: chat.completion
    system_fingerprint: fp_69329525e1
    usage:
      completion_tokens: 9
      prompt_tokens: 438
      total_tokens: 447
  user_input:
    text: turn on livingroom light
    context:
      id: 02PK6NM4K33ZJ7MKEP0RLK2CMJ
      parent_id: null
      user_id: e5c109fc3f1c4jbk89ab2kal455e6ea5
    conversation_id: 01HP6NJ2MDJE4S75RI1JK73N5R
    device_id: null
    language: "*"
  messages:
    - role: system
      content: >-
        I want you to act as smart home manager of Home Assistant.

        I will provide information of smart home along with a question, you will
        truthfully make correction or answer using information provided in one
        sentence in everyday language.


        Current Time: 2024-02-09 19:11:17.136205+09:00


        An overview of the areas and the devices in this smart home:

        Living Room(living_room):
          ```csv
          entity_id,name,state,aliases
          input_boolean.livingroom_light,livingroom_light,off,
          ```
        Bedroom(bedroom):
          ```csv
          entity_id,name,state,aliases
          input_boolean.bedroom_light,bedroom_light,on,
          ```
        Etc:
          ```csv
          entity_id,name,state,aliases
          input_boolean.kitchen_light,kitchen_light,off,
          ```
        Kitchen(kitchen):
          ```csv
          entity_id,name,state,aliases
          todo.shopping_list,Shopping List,0,
          ```

        Answer the user's questions about the world truthfully.

        The current state of devices is provided in available devices.

        Use execute_services function only for requested action, not for current
        states.

        Do not execute service without user's confirmation.

        Do not restate or appreciate what user says, rather make a quick
        inquiry.
    - role: user
      content: turn on livingroom light
    - role: assistant
      tool_calls:
        - id: call_GInkRuIEAbz7MjTvQW4qXWKT
          function:
            arguments: >-
              {"list":[{"domain":"input_boolean","service":"turn_on","service_data":{"entity_id":"input_boolean.livingroom_light"}}]}
            name: execute_services
          type: function
    - tool_call_id: call_GInkRuIEAbz7MjTvQW4qXWKT
      role: tool
      name: execute_services
      content: "[{'success': True}]"
    - content: The living room light has been turned on.
      role: assistant
origin: LOCAL
time_fired: "2024-02-09T10:11:19.388147+00:00"
context:
  id: 01HP6AB9PCDEFZEJ10D35GQD1FV
  parent_id: null
  user_id: null

```

