### PR TITLE
[#140] Make local image to be attached in `query_image` service

### DIFF
--- a/custom_components/extended_openai_conversation/manifest.json
+++ b/custom_components/extended_openai_conversation/manifest.json
@@ -20,5 +20,5 @@
   "requirements": [
     "openai~=1.3.8"
   ],
-  "version": "1.0.3"
+  "version": "1.0.4"
 }


### PR DESCRIPTION
## Issue
- #140

## Objective
- Make local image to be accessible in `extended_openai_conversation.query_image`.

## Example
<img width="900" src="https://github.com/jekalmin/extended_openai_conversation/assets/2917984/fa6cf61f-35d1-43b9-908f-a8fdc6b77dec">
