### PR TITLE
User user_id for user identification

### DIFF
--- a/custom_components/extended_openai_conversation/__init__.py
+++ b/custom_components/extended_openai_conversation/__init__.py
@@ -186,9 +186,9 @@ class OpenAIAgent(conversation.AbstractConversationAgent):
             messages = [system_message]
         user_message = {"role": "user", "content": user_input.text}
         if self.entry.options.get(CONF_ATTACH_USERNAME, DEFAULT_ATTACH_USERNAME):
-            user = await self.hass.auth.async_get_user(user_input.context.user_id)
-            if user is not None and user.name is not None:
-                user_message[ATTR_NAME] = user.name
+            user = user_input.context.user_id
+            if user is not None:
+                user_message[ATTR_NAME] = user
 
         messages.append(user_message)
 

--- a/custom_components/extended_openai_conversation/helpers.py
+++ b/custom_components/extended_openai_conversation/helpers.py
@@ -223,6 +223,10 @@ class NativeFunctionExecutor(FunctionExecutor):
             return await self.get_statistics(
                 hass, function, arguments, user_input, exposed_entities
             )
+        if name == "get_user_from_user_id":
+            return await self.get_user_from_user_id(
+                hass, function, arguments, user_input, exposed_entities
+            )
 
         raise NativeNotFound(name)
 
@@ -371,6 +375,17 @@ class NativeFunctionExecutor(FunctionExecutor):
     ):
         energy_manager: energy.data.EnergyManager = await energy.async_get_manager(hass)
         return energy_manager.data
+
+    async def get_user_from_user_id(
+        self,
+        hass: HomeAssistant,
+        function,
+        arguments,
+        user_input: conversation.ConversationInput,
+        exposed_entities,
+    ):
+        user = await hass.auth.async_get_user(user_input.context.user_id)
+        return {'name': user.name if user and hasattr(user, 'name') else 'Unknown'}
 
     async def get_statistics(
         self,

--- a/examples/function/user_id_to_user/README.md
+++ b/examples/function/user_id_to_user/README.md
@@ -1,0 +1,28 @@
+## Objective
+- Map user_id to friendly user name string
+
+When the option to pass the current user to OpenAI via the user
+message context is enabled, we actually pass the user_id rather than a
+friendly user name as OpenAI has limitations on characters it accepts.
+This function can be used to resolve the user's name, without
+limitation on acceptable characters.
+
+## Function
+
+### get_user_from_user_id
+```yaml
+- spec:
+    name: get_user_from_user_id
+    description: Retrieve users name from the supplied user id hash
+    parameters:
+      type: object
+      properties:
+        user_id:
+          type: string
+          description: user_id
+      required:
+      - user_id
+  function:
+    type: native
+    name: get_user_from_user_id
+```


### PR DESCRIPTION
I have the Voice over IP integration working with extended OpenAI Conversation, which allows me to VoIP connect into the voice assistant.  However, to make this work we need to pass an acceptable user.name to OpenAI which does not allow spaces.

Currently this is the error we receive:

Error code: 400 - {'error': {'message': "'Voice over IP' does not match '^[a-zA-Z0-9_-]{1,64}$' - 'messages.1.name'", 'type': 'invalid_request_error', 'param': None, 'code': None}}

The attached patch converts spaces to underscores, and the VoIP integration now works well with this integration.