### PR TITLE
Fix example YouTube scripts

### DIFF
--- a/examples/function/youtube/README.md
+++ b/examples/function/youtube/README.md
@@ -91,14 +91,14 @@ script:
         media_content_type: url
         media_content_id: >-
           {% if kind == 'video' %}
-            "youtube://www.youtube.com/watch?v={{content_id}}"
+            youtube://www.youtube.com/watch?v={{content_id}}
           {% elif kind == 'channel' %}
-            "youtube://www.youtube.com/channel/{{content_id}}"
+            youtube://www.youtube.com/channel/{{content_id}}
           {% else %} 
-            "youtube://www.youtube.com/playlist?list={{content_id}}"
+            youtube://www.youtube.com/playlist?list={{content_id}}
           {% endif %}
-        target:
-          entity_id: "{{ entity_id }}"
+      target:
+        entity_id: "{{ entity_id }}"
 ```
 
 #### Android TV
@@ -145,11 +145,11 @@ script:
       data:
         activity: >-
           {% if kind == 'video' %}
-            "https://www.youtube.com/watch?v={{content_id}}"
+            https://www.youtube.com/watch?v={{content_id}}
           {% elif kind == 'channel' %}
-            "https://www.youtube.com/channel/{{content_id}}"
+            https://www.youtube.com/channel/{{content_id}}
           {% else %}  {# playlist kind #}
-            "https://www.youtube.com/playlist?list={{content_id}}"
+            https://www.youtube.com/playlist?list={{content_id}}
           {% endif %}
       target:
         entity_id: "{{ player }}"


### PR DESCRIPTION
Hi,

Thanks for creating this quality integration! I've been having a lot of fun using it.

I followed the YouTube example to play on my Apple TV and ran into an error from an indentation typo in the script yaml.

I also noticed that the youtube urls were being double quoted in the execution trace of the script (though this did not result in an error):

> media_content_id: '"youtube://www.youtube.com/playlist?list=WL"'

This PR fixes both of those issues.
