### PR TITLE
Update README.md according to calendar example file

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,12 +245,14 @@ In order to pass result of calling service to OpenAI, set response variable to `
   function:
     type: script
     sequence:
-    - service: calendar.list_events
+    - service: calendar.get_events
       data:
         start_date_time: "{{start_date_time}}"
         end_date_time: "{{end_date_time}}"
       target:
-        entity_id: calendar.test
+        entity_id:
+        - calendar.[YourCalendarHere]
+        - calendar.[MoreCalendarsArePossible]
       response_variable: _function_result
 ```
 


### PR DESCRIPTION
just copied the new example as calendar.list_events is deprecated.