### PR TITLE
Fix conversation_id renew every time

### DIFF
--- a/custom_components/extended_openai_conversation/__init__.py
+++ b/custom_components/extended_openai_conversation/__init__.py
@@ -167,8 +167,10 @@ class OpenAIAgent(conversation.AbstractConversationAgent):
             conversation_id = user_input.conversation_id
             messages = self.history[conversation_id]
         else:
-            conversation_id = ulid.ulid()
-            user_input.conversation_id = conversation_id
+            conversation_id = user_input.conversation_id
+            if user_input.conversation_id is None:
+                conversation_id = ulid.ulid()
+                user_input.conversation_id = conversation_id
             try:
                 system_message = self._generate_system_message(
                     exposed_entities, user_input


### PR DESCRIPTION
In this fork I fixed an issue where the dialog with wyoming satellite starts again every time even though the conversation_id is provided.
Related to [this](https://github.com/jekalmin/extended_openai_conversation/issues/241).