### PR TITLE
[#217] resolve "blocking call" warning log.

### DIFF
--- a/custom_components/extended_openai_conversation/__init__.py
+++ b/custom_components/extended_openai_conversation/__init__.py
@@ -30,6 +30,7 @@ from homeassistant.helpers import (
     intent,
     template,
 )
+from homeassistant.helpers.httpx_client import get_async_client
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.util import ulid
 
@@ -145,12 +146,14 @@ class OpenAIAgent(conversation.AbstractConversationAgent):
                 azure_endpoint=base_url,
                 api_version=entry.data.get(CONF_API_VERSION),
                 organization=entry.data.get(CONF_ORGANIZATION),
+                http_client=get_async_client(hass),
             )
         else:
             self.client = AsyncOpenAI(
                 api_key=entry.data[CONF_API_KEY],
                 base_url=base_url,
                 organization=entry.data.get(CONF_ORGANIZATION),
+                http_client=get_async_client(hass),
             )
 
     @property

--- a/custom_components/extended_openai_conversation/helpers.py
+++ b/custom_components/extended_openai_conversation/helpers.py
@@ -39,6 +39,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant, State
 from homeassistant.exceptions import HomeAssistantError, ServiceNotFound
 from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.httpx_client import get_async_client
 from homeassistant.helpers.script import Script
 from homeassistant.helpers.template import Template
 import homeassistant.util.dt as dt_util
@@ -141,10 +142,14 @@ async def validate_authentication(
             azure_endpoint=base_url,
             api_version=api_version,
             organization=organization,
+            http_client=get_async_client(hass),
         )
     else:
         client = AsyncOpenAI(
-            api_key=api_key, base_url=base_url, organization=organization
+            api_key=api_key,
+            base_url=base_url,
+            organization=organization,
+            http_client=get_async_client(hass),
         )
 
     await client.models.list(timeout=10)


### PR DESCRIPTION
## Issue
- #217

```
2024-10-27 13:45:53.213 WARNING (MainThread) [homeassistant.util.loop] Detected blocking call to load_verify_locations with args (<ssl.SSLContext object at 0x7bebd793ddd0>,) inside the event loop by custom integration 'extended_openai_conversation' at custom_components/extended_openai_conversation/helpers.py, line 146: client = AsyncOpenAI( (offender: /home/vscode/.local/ha-venv/lib/python3.12/site-packages/httpx/_config.py, line 149: context.load_verify_locations(cafile=cafile)), please create a bug report at https://github.com/jekalmin/extended_openai_conversation/issues
For developers, please see https://developers.home-assistant.io/docs/asyncio_blocking_operations/#load_verify_locations
```
## Objective
- Fix blocking call to verify cafile.