### PR TITLE
Update AZURE_DOMAIN_PATTERN to accept other regex pattern

### DIFF
--- a/custom_components/extended_openai_conversation/helpers.py
+++ b/custom_components/extended_openai_conversation/helpers.py
@@ -58,7 +58,7 @@ from .exceptions import (
 _LOGGER = logging.getLogger(__name__)
 
 
-AZURE_DOMAIN_PATTERN = r"\.(openai\.azure\.com|azure-api\.net)"
+AZURE_DOMAIN_PATTERN = r"\.(openai\.azure\.com|azure-api\.net|services\.ai\.azure\.com)"
 
 
 def get_function_executor(value: str):


### PR DESCRIPTION
Update AZURE_DOMAIN_PATTERN to include services.ai.azure.com as a valid Azure API base URL. 
### User Case 
``` 
API_KEY=XXXXX
API_Base_URL=https://xxxxx.services.ai.azure.com/models/chat/completions?api-version=2024-05-01-preview
API_VERSION=2024-05-01-preview
```
Tested on DeepSeek-R1 deployment on Azure AI Foundry.