### PR TITLE
Add check for response.usage before token limit

### DIFF
--- a/custom_components/extended_openai_conversation/__init__.py
+++ b/custom_components/extended_openai_conversation/__init__.py
@@ -372,7 +372,7 @@ class OpenAIAgent(conversation.AbstractConversationAgent):
 
         _LOGGER.info("Response %s", json.dumps(response.model_dump(exclude_none=True)))
 
-        if response.usage.total_tokens > context_threshold:
+        if response.usage and response.usage.total_tokens > context_threshold:
             await self.truncate_message_history(messages, exposed_entities, user_input)
 
         choice: Choice = response.choices[0]


### PR DESCRIPTION
This was reported in #273, but then closed as the author found a workaround. The workaround is not the correct solution though, because that involves bypassing Open WebUI and using the `/ollama/` api directly. Doing so removes the ability to use Open WebUI's custom models.

The correct fix is to check that `.usage` exists before using it.

Note that I left the later `reason="length"` usage, because that error type does imply that usage data is accessible, so if you get to that point, then there really should be a `.usage` object available.

After the fix, I'm able to use my Open WebUI custom model within the Extended OpenAI Conversation agent.