### PR TITLE
fix: Use max_completion_tokens for newer models and fix auth blocking…

### DIFF
--- a/custom_components/extended_openai_conversation/conversation.py
+++ b/custom_components/extended_openai_conversation/conversation.py
@@ -363,13 +363,22 @@ class ExtendedOpenAIAgentEntity(
 
         _LOGGER.info("Prompt for %s: %s", model, json.dumps(messages))
 
+        # Determine which token parameter to use based on model
+        # Newer models (gpt-4o, gpt-5, o1, o3, etc.) require max_completion_tokens
+        model_lower = model.lower()
+        use_new_token_param = any(
+            model_lower.startswith(prefix) or f"-{prefix}" in model_lower
+            for prefix in ("gpt-4o", "gpt-5", "o1", "o3", "o4")
+        )
+        token_kwargs = {"max_completion_tokens": max_tokens} if use_new_token_param else {"max_tokens": max_tokens}
+
         response = await self.client.chat.completions.create(
             model=model,
             messages=messages,
-            max_tokens=max_tokens,
             top_p=top_p,
             temperature=temperature,
             user=user_input.conversation_id,
+            **token_kwargs,
             **tool_kwargs,
         )
 


### PR DESCRIPTION
# Extended OpenAI Conversation - Fixes for Home Assistant 2025.12.x and GPT-4o/5.x Models

## Summary

This PR addresses two critical issues:

~~1. **Blocking Event Loop during Authentication** - The `validate_authentication` function was creating `AsyncOpenAI`/`AsyncAzureOpenAI` clients in the async context but calling them synchronously via `async_add_executor_job`, which caused import errors and blocking SSL certificate loading in the event loop.~~

2. **Unsupported `max_tokens` Parameter for Newer Models** - Newer OpenAI models (GPT-4o, GPT-5.x etc.) require the `max_completion_tokens` parameter instead of `max_tokens`, causing API errors.

---

~~## Issue 1: Authentication Blocking Event Loop~~

~~### Problem~~

~~When adding the integration, users encountered:
- `ImportError: cannot import name 'omit' from 'openai._types'`
- `Detected blocking call to load_verify_locations inside the event loop`~~

~~The root cause was that `AsyncOpenAI` client instantiation loads SSL certificates synchronously, blocking the event loop. Additionally, calling `client.models.list()` on an async client returns an `AsyncPaginator` that wasn't being awaited properly when run via `async_add_executor_job`.~~

### Solution

Changed `validate_authentication` to use synchronous `OpenAI` and `AzureOpenAI` clients, with all client creation and API calls moved into a separate sync function that runs entirely in the executor.

### Files Changed

**`helpers.py`** - Lines 13, 129-174

#### Before (Line 13):
```python
from openai import AsyncAzureOpenAI, AsyncOpenAI
```

#### After (Line 13):
```python
from openai import AsyncAzureOpenAI, AsyncOpenAI, AzureOpenAI, OpenAI
```

#### Before (Lines 129-159):
```python
async def validate_authentication(
    hass: HomeAssistant,
    api_key: str,
    base_url: str,
    api_version: str,
    organization: str = None,
    skip_authentication=False,
) -> None:
    if skip_authentication:
        return

    if is_azure(base_url):
        client = AsyncAzureOpenAI(
            api_key=api_key,
            azure_endpoint=base_url,
            api_version=api_version,
            organization=organization,
            http_client=get_async_client(hass),
        )
    else:
        client = AsyncOpenAI(
            api_key=api_key,
            base_url=base_url,
            organization=organization,
            http_client=get_async_client(hass),
        )

    await hass.async_add_executor_job(partial(client.models.list, timeout=10))
```

#### After (Lines 129-174):
```python
def _sync_validate_authentication(
    api_key: str,
    base_url: str,
    api_version: str,
    organization: str,
    is_azure_endpoint: bool,
) -> None:
    """Synchronous authentication validation to run in executor."""
    if is_azure_endpoint:
        client = AzureOpenAI(
            api_key=api_key,
            azure_endpoint=base_url,
            api_version=api_version,
            organization=organization,
        )
    else:
        client = OpenAI(
            api_key=api_key,
            base_url=base_url,
            organization=organization,
        )
    client.models.list(timeout=10)


async def validate_authentication(
    hass: HomeAssistant,
    api_key: str,
    base_url: str,
    api_version: str,
    organization: str = None,
    skip_authentication=False,
) -> None:
    if skip_authentication:
        return

    await hass.async_add_executor_job(
        _sync_validate_authentication,
        api_key,
        base_url,
        api_version,
        organization,
        is_azure(base_url),
    )
```

---
~~
## Issue 2: `max_tokens` vs `max_completion_tokens`

### Problem

When using GPT-4o, GPT-5.x, o1, o3, or other newer models, the API returns:
```
Error code: 400 - {'error': {'message': "Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead.", 'type': 'invalid_request_error', 'param': 'max_tokens', 'code': 'unsupported_parameter'}}
```

### Solution

Added model detection logic to use `max_completion_tokens` for newer models and `max_tokens` for older models.

### Files Changed

**`__init__.py`** - Lines 363-383

#### Before (Lines 363-375):
```python
        _LOGGER.info("Prompt for %s: %s", model, json.dumps(messages))

        response: ChatCompletion = await self.client.chat.completions.create(
            model=model,
            messages=messages,
            max_tokens=max_tokens,
            top_p=top_p,
            temperature=temperature,
            user=user_input.conversation_id,
            **tool_kwargs,
        )
```

#### After (Lines 363-386):
```python
        _LOGGER.info("Prompt for %s: %s", model, json.dumps(messages))

        # Determine which token parameter to use based on model
        # Newer models (gpt-4o, gpt-5, o1, o3, etc.) require max_completion_tokens
        # Older models use max_tokens
        model_lower = model.lower()
        use_new_token_param = any(x in model_lower for x in ['gpt-4o', 'gpt-5', 'o1-', 'o1', 'o3-', 'o3'])
        
        if use_new_token_param:
            token_kwargs = {"max_completion_tokens": max_tokens}
        else:
            token_kwargs = {"max_tokens": max_tokens}

        response: ChatCompletion = await self.client.chat.completions.create(
            model=model,
            messages=messages,
            top_p=top_p,
            temperature=temperature,
            user=user_input.conversation_id,
            **token_kwargs,
            **tool_kwargs,
        )
```

---

**`services.py`** - Lines 63-79

#### Before (Lines 63-72):
```python
            _LOGGER.info("Prompt for %s: %s", model, messages)

            response = await AsyncOpenAI(
                api_key=hass.data[DOMAIN][call.data["config_entry"]]["api_key"]
            ).chat.completions.create(
                model=model,
                messages=messages,
                max_tokens=call.data["max_tokens"],
            )
```

#### After (Lines 63-81):
```python
            _LOGGER.info("Prompt for %s: %s", model, messages)

            # Determine which token parameter to use based on model
            model_lower = model.lower()
            use_new_token_param = any(x in model_lower for x in ['gpt-4o', 'gpt-5', 'o1-', 'o1', 'o3-', 'o3'])
            
            if use_new_token_param:
                token_kwargs = {"max_completion_tokens": call.data["max_tokens"]}
            else:
                token_kwargs = {"max_tokens": call.data["max_tokens"]}

            response = await AsyncOpenAI(
                api_key=hass.data[DOMAIN][call.data["config_entry"]]["api_key"]
            ).chat.completions.create(
                model=model,
                messages=messages,
                **token_kwargs,
            )
```

---

## Testing

1. **Authentication Test**: Successfully added Extended OpenAI Conversation integration with Azure OpenAI endpoint (`https://deployment.openai.azure.com`) without blocking event loop warnings.

2. **Model Compatibility Test**: Successfully used `gpt-5.1-chat` deployment via Azure OpenAI Foundry without `max_tokens` errors.

## Compatibility

- Home Assistant 2025.12.x
- Python 3.13
- OpenAI library 2.8.0
- Azure OpenAI and standard OpenAI API endpoints

## Related Issues

- Fixes #345 (HA 2025.12.x compatibility)
- Fixes `max_tokens` incompatibility with GPT-4o/5.x models
