### PR TITLE
feat: Add continue_conversation support for follow-up questions

### DIFF
--- a/custom_components/extended_openai_conversation/__init__.py
+++ b/custom_components/extended_openai_conversation/__init__.py
@@ -231,8 +231,22 @@ class OpenAIAgent(conversation.AbstractConversationAgent):
 
         intent_response = intent.IntentResponse(language=user_input.language)
         intent_response.async_set_speech(query_response.message.content)
+
+        # Detect if LLM is asking a follow-up question to enable continued conversation
+        response_text = query_response.message.content or ""
+        should_continue = (
+            response_text.rstrip().endswith("?") or
+            any(phrase in response_text.lower() for phrase in [
+                "which one", "would you like", "do you want", "would you prefer",
+                "which do you", "what would you", "shall i", "should i",
+                "choose from", "select from", "pick from"
+            ])
+        )
+
         return conversation.ConversationResult(
-            response=intent_response, conversation_id=conversation_id
+            response=intent_response,
+            conversation_id=conversation_id,
+            continue_conversation=should_continue
         )
 
     def _generate_system_message(


### PR DESCRIPTION
## Summary
Implements automatic detection of follow-up questions from the LLM response to enable continued conversation mode (introduced in HA 2025.4).

## Problem
Currently, when the LLM asks a clarifying question (e.g., "I found 3 stations matching that. Which one would you like?"), the voice satellite's microphone closes and the user has to re-trigger it to respond.

## Solution
Detect when the LLM response is asking a follow-up question by checking if:
- The response ends with a question mark (`?`)
- The response contains common question phrases like "which one", "would you like", "do you want", etc.

When detected, `continue_conversation=True` is passed to `ConversationResult`, keeping the microphone active.

## Testing
Tested with Home Assistant Voice Preview Edition and ESPHome voice satellites. When asking "play progressive radio" and multiple stations match, the assistant asks which one and the microphone stays open for the response.

Closes #312