### PR TITLE
[#338] Add API Provider (OpenAI, Azure OpenAI) selection

### DIFF
--- a/custom_components/extended_openai_conversation/__init__.py
+++ b/custom_components/extended_openai_conversation/__init__.py
@@ -24,6 +24,8 @@ from .const import (
     CONF_ORGANIZATION,
     CONF_SKIP_AUTHENTICATION,
     DEFAULT_SKIP_AUTHENTICATION,
+    CONF_API_PROVIDER,
+    DEFAULT_API_PROVIDER,
     DOMAIN,
 )
 from .helpers import get_authenticated_client
@@ -59,6 +61,7 @@ async def async_setup_entry(
             skip_authentication=entry.data.get(
                 CONF_SKIP_AUTHENTICATION, DEFAULT_SKIP_AUTHENTICATION
             ),
+            api_provider=entry.data.get(CONF_API_PROVIDER, DEFAULT_API_PROVIDER),
         )
     except AuthenticationError as err:
         _LOGGER.error("Invalid API key: %s", err)

--- a/custom_components/extended_openai_conversation/const.py
+++ b/custom_components/extended_openai_conversation/const.py
@@ -10,6 +10,9 @@ DEFAULT_CONF_BASE_URL = "https://api.openai.com/v1"
 CONF_API_VERSION = "api_version"
 CONF_SKIP_AUTHENTICATION = "skip_authentication"
 DEFAULT_SKIP_AUTHENTICATION = False
+CONF_API_PROVIDER = "api_provider"
+API_PROVIDERS = [{"key": "openai", "label": "OpenAI"}, {"key": "azure", "label": "Azure OpenAI"}]
+DEFAULT_API_PROVIDER = API_PROVIDERS[0]["key"]
 
 EVENT_AUTOMATION_REGISTERED = "automation_registered_via_extended_openai_conversation"
 EVENT_CONVERSATION_FINISHED = "extended_openai_conversation.conversation.finished"

--- a/custom_components/extended_openai_conversation/helpers.py
+++ b/custom_components/extended_openai_conversation/helpers.py
@@ -70,7 +70,8 @@ def get_function_executor(value: str):
     return function_executor
 
 
-def is_azure(base_url: str | None) -> bool:
+def is_azure_url(base_url: str | None) -> bool:
+    """Check if the base URL is an Azure OpenAI URL."""
     if base_url and re.search(AZURE_DOMAIN_PATTERN, base_url):
         return True
     return False
@@ -134,11 +135,12 @@ async def get_authenticated_client(
     base_url: str | None,
     api_version: str | None,
     organization: str | None,
+    api_provider: str | None,
     skip_authentication=False,
 ) -> AsyncClient:
     """Validate OpenAI authentication."""
 
-    if base_url and is_azure(base_url):
+    if base_url and (is_azure_url(base_url) or api_provider == "azure"):
         client = AsyncAzureOpenAI(
             api_key=api_key,
             azure_endpoint=base_url,

--- a/custom_components/extended_openai_conversation/strings.json
+++ b/custom_components/extended_openai_conversation/strings.json
@@ -8,7 +8,8 @@
           "base_url": "[%key:common::config_flow::data::base_url%]",
           "api_version": "[%key:common::config_flow::data::api_version%]",
           "organization": "[%key:common::config_flow::data::organization%]",
-          "skip_authentication": "[%key:common::config_flow::data::skip_authentication%]"
+          "skip_authentication": "[%key:common::config_flow::data::skip_authentication%]",
+          "api_provider": "[%key:common::config_flow::data::api_provider%]"
         }
       }
     },

--- a/custom_components/extended_openai_conversation/translations/de.json
+++ b/custom_components/extended_openai_conversation/translations/de.json
@@ -13,7 +13,8 @@
                     "base_url": "Base Url",
                     "api_version": "Api Version",
                     "organization": "Organization",
-                    "skip_authentication": "Authentifizierung überspringen"
+                    "skip_authentication": "Authentifizierung überspringen",
+                    "api_provider": "Api Provider"
                 }
             }
         }

--- a/custom_components/extended_openai_conversation/translations/el.json
+++ b/custom_components/extended_openai_conversation/translations/el.json
@@ -13,7 +13,8 @@
                     "base_url": "Βασική Διεύθυνση",
                     "api_version": "Έκδοση API",
                     "organization": "Οργανισμός",
-                    "skip_authentication": "Παράλειψη Ελέγχου Ταυτότητας"
+                    "skip_authentication": "Παράλειψη Ελέγχου Ταυτότητας",
+                    "api_provider": "Api Provider"
                 }
             }
         }

--- a/custom_components/extended_openai_conversation/translations/en.json
+++ b/custom_components/extended_openai_conversation/translations/en.json
@@ -13,7 +13,8 @@
                     "base_url": "Base Url",
                     "api_version": "Api Version",
                     "organization": "Organization",
-                    "skip_authentication": "Skip Authentication"
+                    "skip_authentication": "Skip Authentication",
+                    "api_provider": "Api Provider"
                 }
             }
         }

--- a/custom_components/extended_openai_conversation/translations/fr.json
+++ b/custom_components/extended_openai_conversation/translations/fr.json
@@ -13,7 +13,8 @@
                     "base_url": "Base de l'URL",
                     "api_version": "Version de l'API",
                     "organization": "Organization",
-                    "skip_authentication": "Ignorer l'authentification"
+                    "skip_authentication": "Ignorer l'authentification",
+                    "api_provider": "Api Provider"
                 }
             }
         }

--- a/custom_components/extended_openai_conversation/translations/hu.json
+++ b/custom_components/extended_openai_conversation/translations/hu.json
@@ -13,7 +13,8 @@
                     "base_url": "Base Url",
                     "api_version": "API Verzió",
                     "organization": "Organization",
-                    "skip_authentication": "Azonosítás átugrása"
+                    "skip_authentication": "Azonosítás átugrása",
+                    "api_provider": "Api Provider"
                 }
             }
         }

--- a/custom_components/extended_openai_conversation/translations/it.json
+++ b/custom_components/extended_openai_conversation/translations/it.json
@@ -12,7 +12,8 @@
                     "api_key": "Chiave API",
                     "base_url": "URL di base",
                     "api_version": "Versione API",
-                    "skip_authentication": "Ignora autenticazione"
+                    "skip_authentication": "Ignora autenticazione",
+                    "api_provider": "Api Provider"
                 }
             }
         }

--- a/custom_components/extended_openai_conversation/translations/ko.json
+++ b/custom_components/extended_openai_conversation/translations/ko.json
@@ -13,7 +13,8 @@
                     "base_url": "Base Url",
                     "api_version": "Api Version",
                     "organization": "Organization",
-                    "skip_authentication": "Skip Authentication"
+                    "skip_authentication": "Skip Authentication",
+                    "api_provider": "Api Provider"
                 }
             }
         }

--- a/custom_components/extended_openai_conversation/translations/nl.json
+++ b/custom_components/extended_openai_conversation/translations/nl.json
@@ -13,7 +13,8 @@
                     "base_url": "Basis URL",
                     "api_version": "API Version",
                     "organization": "Organization",
-                    "skip_authentication": "Authenticatie overslaan"
+                    "skip_authentication": "Authenticatie overslaan",
+                    "api_provider": "Api Provider"
                 }
             }
         }

--- a/custom_components/extended_openai_conversation/translations/pl.json
+++ b/custom_components/extended_openai_conversation/translations/pl.json
@@ -13,7 +13,8 @@
                     "base_url": "Bazowy URL",
                     "api_version": "Wersja API",
                     "organization": "Organizacja",
-                    "skip_authentication": "Pomiń authentykację"
+                    "skip_authentication": "Pomiń authentykację",
+                    "api_provider": "Api Provider"
                 }
             }
         }

--- a/custom_components/extended_openai_conversation/translations/pt-BR.json
+++ b/custom_components/extended_openai_conversation/translations/pt-BR.json
@@ -13,7 +13,8 @@
                     "base_url": "Base Url",
                     "api_version": "Versão da API",
                     "organization": "Organização",
-                    "skip_authentication": "Pular autenticação"
+                    "skip_authentication": "Pular autenticação",
+                    "api_provider": "Api Provider"
                 }
             }
         }

--- a/custom_components/extended_openai_conversation/translations/pt.json
+++ b/custom_components/extended_openai_conversation/translations/pt.json
@@ -13,7 +13,8 @@
                     "base_url": "Base Url",
                     "api_version": "Versão da API",
                     "organization": "Organização",
-                    "skip_authentication": "Saltar autenticação"
+                    "skip_authentication": "Saltar autenticação",
+                    "api_provider": "Api Provider"
                 }
             }
         }


### PR DESCRIPTION
## Link
- #338
- #231

## Objective
- Azure OpenAI that doesn't match pattern (`openai.azure.com`, `azure-api.net`, `services.ai.azure.com`) can be configured manually.