### PR TITLE
[#359] "Use Tools" option is "true" by default

### DIFF
--- a/custom_components/extended_openai_conversation/const.py
+++ b/custom_components/extended_openai_conversation/const.py
@@ -11,7 +11,10 @@ CONF_API_VERSION = "api_version"
 CONF_SKIP_AUTHENTICATION = "skip_authentication"
 DEFAULT_SKIP_AUTHENTICATION = False
 CONF_API_PROVIDER = "api_provider"
-API_PROVIDERS = [{"key": "openai", "label": "OpenAI"}, {"key": "azure", "label": "Azure OpenAI"}]
+API_PROVIDERS = [
+    {"key": "openai", "label": "OpenAI"},
+    {"key": "azure", "label": "Azure OpenAI"},
+]
 DEFAULT_API_PROVIDER = API_PROVIDERS[0]["key"]
 
 EVENT_AUTOMATION_REGISTERED = "automation_registered_via_extended_openai_conversation"
@@ -92,7 +95,7 @@ DEFAULT_CONF_FUNCTIONS = [
 CONF_ATTACH_USERNAME = "attach_username"
 DEFAULT_ATTACH_USERNAME = False
 CONF_USE_TOOLS = "use_tools"
-DEFAULT_USE_TOOLS = False
+DEFAULT_USE_TOOLS = True
 CONF_CONTEXT_THRESHOLD = "context_threshold"
 DEFAULT_CONTEXT_THRESHOLD = 13000
 CONTEXT_TRUNCATE_STRATEGIES = [{"key": "clear", "label": "Clear All Messages"}]

--- a/custom_components/extended_openai_conversation/strings.json
+++ b/custom_components/extended_openai_conversation/strings.json
@@ -34,6 +34,9 @@
           "use_tools": "Use Tools",
           "context_threshold": "Context Threshold",
           "context_truncate_strategy": "Context truncation strategy when exceeded threshold"
+        },
+        "data_description": {
+          "use_tools": "Whether to use tool calling or function calling in the conversation. If disabled, function calling will be used (see https://platform.openai.com/docs/guides/function-calling)"
         }
       }
     }

--- a/custom_components/extended_openai_conversation/translations/de.json
+++ b/custom_components/extended_openai_conversation/translations/de.json
@@ -40,6 +40,9 @@
                         "use_tools": "Use Tools",
                         "context_threshold": "Context Threshold",
                         "context_truncate_strategy": "Context truncation strategy when exceeded threshold"
+                    },
+                    "data_description": {
+                        "use_tools": "Whether to use tool calling or function calling in the conversation. If disabled, function calling will be used (see https://platform.openai.com/docs/guides/function-calling)"
                     }
                 }
             }

--- a/custom_components/extended_openai_conversation/translations/el.json
+++ b/custom_components/extended_openai_conversation/translations/el.json
@@ -40,6 +40,9 @@
                         "use_tools": "Χρήση Εργαλείων",
                         "context_threshold": "Όριο Περιεχομένου",
                         "context_truncate_strategy": "Στρατηγική περικοπής περιεχομένου όταν ξεπεραστεί το όριο"
+                    },
+                    "data_description": {
+                        "use_tools": "Whether to use tool calling or function calling in the conversation. If disabled, function calling will be used (see https://platform.openai.com/docs/guides/function-calling)"
                     }
                 }
             }

--- a/custom_components/extended_openai_conversation/translations/en.json
+++ b/custom_components/extended_openai_conversation/translations/en.json
@@ -40,6 +40,9 @@
                         "use_tools": "Use Tools",
                         "context_threshold": "Context Threshold",
                         "context_truncate_strategy": "Context truncation strategy when exceeded threshold"
+                    },
+                    "data_description": {
+                        "use_tools": "Whether to use tool calling or function calling in the conversation. If disabled, function calling will be used (see https://platform.openai.com/docs/guides/function-calling)"
                     }
                 }
             }

--- a/custom_components/extended_openai_conversation/translations/fr.json
+++ b/custom_components/extended_openai_conversation/translations/fr.json
@@ -40,6 +40,9 @@
                         "use_tools": "Use Tools",
                         "context_threshold": "Context Threshold",
                         "context_truncate_strategy": "Context truncation strategy when exceeded threshold"
+                    },
+                    "data_description": {
+                        "use_tools": "Whether to use tool calling or function calling in the conversation. If disabled, function calling will be used (see https://platform.openai.com/docs/guides/function-calling)"
                     }
                 }
             }

--- a/custom_components/extended_openai_conversation/translations/hu.json
+++ b/custom_components/extended_openai_conversation/translations/hu.json
@@ -40,6 +40,9 @@
                         "use_tools": "Use Tools",
                         "context_threshold": "Context Threshold",
                         "context_truncate_strategy": "Context truncation strategy when exceeded threshold"
+                    },
+                    "data_description": {
+                        "use_tools": "Whether to use tool calling or function calling in the conversation. If disabled, function calling will be used (see https://platform.openai.com/docs/guides/function-calling)"
                     }
                 }
             }

--- a/custom_components/extended_openai_conversation/translations/it.json
+++ b/custom_components/extended_openai_conversation/translations/it.json
@@ -39,6 +39,9 @@
                         "use_tools": "Utilizza strumenti",
                         "context_threshold": "Soglia di contesto",
                         "context_truncate_strategy": "Strategia di troncamento del contesto quando superata la soglia"
+                    },
+                    "data_description": {
+                        "use_tools": "Whether to use tool calling or function calling in the conversation. If disabled, function calling will be used (see https://platform.openai.com/docs/guides/function-calling)"
                     }
                 }
             }

--- a/custom_components/extended_openai_conversation/translations/ko.json
+++ b/custom_components/extended_openai_conversation/translations/ko.json
@@ -40,6 +40,9 @@
                         "use_tools": "Use Tools",
                         "context_threshold": "Context Threshold",
                         "context_truncate_strategy": "Context truncation strategy when exceeded threshold"
+                    },
+                    "data_description": {
+                        "use_tools": "Whether to use tool calling or function calling in the conversation. If disabled, function calling will be used (see https://platform.openai.com/docs/guides/function-calling)"
                     }
                 }
             }

--- a/custom_components/extended_openai_conversation/translations/nl.json
+++ b/custom_components/extended_openai_conversation/translations/nl.json
@@ -40,6 +40,9 @@
                         "use_tools": "Use Tools",
                         "context_threshold": "Context Threshold",
                         "context_truncate_strategy": "Context truncation strategy when exceeded threshold"
+                    },
+                    "data_description": {
+                        "use_tools": "Whether to use tool calling or function calling in the conversation. If disabled, function calling will be used (see https://platform.openai.com/docs/guides/function-calling)"
                     }
                 }
             }

--- a/custom_components/extended_openai_conversation/translations/pl.json
+++ b/custom_components/extended_openai_conversation/translations/pl.json
@@ -40,6 +40,9 @@
                         "use_tools": "Używaj narzędzi",
                         "context_threshold": "Limit kontekstu",
                         "context_truncate_strategy": "Co zrobić z kontekstem, gdy przekroczony limit"
+                    },
+                    "data_description": {
+                        "use_tools": "Whether to use tool calling or function calling in the conversation. If disabled, function calling will be used (see https://platform.openai.com/docs/guides/function-calling)"
                     }
                 }
             }

--- a/custom_components/extended_openai_conversation/translations/pt-BR.json
+++ b/custom_components/extended_openai_conversation/translations/pt-BR.json
@@ -40,6 +40,9 @@
                         "use_tools": "Use ferramentas",
                         "context_threshold": "Limite do contexto",
                         "context_truncate_strategy": "Estratégia de truncamento de contexto quando o limite é excedido"
+                    },
+                    "data_description": {
+                        "use_tools": "Whether to use tool calling or function calling in the conversation. If disabled, function calling will be used (see https://platform.openai.com/docs/guides/function-calling)"
                     }
                 }
             }

--- a/custom_components/extended_openai_conversation/translations/pt.json
+++ b/custom_components/extended_openai_conversation/translations/pt.json
@@ -40,6 +40,9 @@
                         "use_tools": "Use ferramentas",
                         "context_threshold": "Limite do contexto",
                         "context_truncate_strategy": "Estratégia de limite de contexto quando o limite é excedido"
+                    },
+                    "data_description": {
+                        "use_tools": "Whether to use tool calling or function calling in the conversation. If disabled, function calling will be used (see https://platform.openai.com/docs/guides/function-calling)"
                     }
                 }
             }


### PR DESCRIPTION
## Links
- #359 

## Objectives
- `Use Tools` option is `True` by default. It was, by default, `False` to remain compatible with models which use function call.