### PR TITLE
Add "user_input" variable in system prompt to support extra_system_prompt

### DIFF
--- a/custom_components/extended_openai_conversation/const.py
+++ b/custom_components/extended_openai_conversation/const.py
@@ -38,6 +38,8 @@ The current state of devices is provided in available devices.
 Use execute_services function only for requested action, not for current states.
 Do not execute service without user's confirmation.
 Do not restate or appreciate what user says, rather make a quick inquiry.
+
+{{ user_input.extra_system_prompt | default('', true) }}
 """
 CONF_CHAT_MODEL = "chat_model"
 DEFAULT_CHAT_MODEL = "gpt-4o-mini"

--- a/custom_components/extended_openai_conversation/conversation.py
+++ b/custom_components/extended_openai_conversation/conversation.py
@@ -257,6 +257,7 @@ class ExtendedOpenAIAgentEntity(
                 "ha_name": self.hass.config.location_name,
                 "exposed_entities": exposed_entities,
                 "current_device_id": user_input.device_id,
+                "user_input": user_input,
             },
             parse_result=False,
         )


### PR DESCRIPTION
## Objectives
- To support "extra_system_prompt" such as `assist_satelite.start_conversation`
<img width="1252" height="432" alt="스크린샷 2025-12-28 오후 8 59 40" src="https://github.com/user-attachments/assets/b8a48339-85fb-48e0-b711-50abe0de5b5a" />
