### PR TITLE
Better support for different GPT models and refactor decision out of hard coded strings

### DIFF
--- a/custom_components/extended_openai_conversation/const.py
+++ b/custom_components/extended_openai_conversation/const.py
@@ -48,7 +48,7 @@ MODEL_PARAMETER_SUPPORT = (
 
 MODEL_TOKEN_PARAMETER_SUPPORT = (
     {
-        "pattern": r"(^|-)gpt-4o|(^|-)gpt-5|(^|-)o1|(^|-)o3|(^|-)o4",
+        "pattern": r"(^|-)(gpt-4o|gpt-5|o1|o3|o4)",
         "token_param": "max_completion_tokens",
     },
 )

--- a/custom_components/extended_openai_conversation/const.py
+++ b/custom_components/extended_openai_conversation/const.py
@@ -41,6 +41,18 @@ Do not restate or appreciate what user says, rather make a quick inquiry.
 """
 CONF_CHAT_MODEL = "chat_model"
 DEFAULT_CHAT_MODEL = "gpt-4o-mini"
+
+MODEL_PARAMETER_SUPPORT = (
+    {"pattern": r"^gpt-5-(mini|nano)", "unsupported_params": {"top_p"}},
+)
+
+MODEL_TOKEN_PARAMETER_SUPPORT = (
+    {
+        "pattern": r"(^|-)gpt-4o|(^|-)gpt-5|(^|-)o1|(^|-)o3|(^|-)o4",
+        "token_param": "max_completion_tokens",
+    },
+)
+DEFAULT_TOKEN_PARAM = "max_tokens"
 CONF_MAX_TOKENS = "max_tokens"
 DEFAULT_MAX_TOKENS = 150
 CONF_TOP_P = "top_p"

--- a/custom_components/extended_openai_conversation/helpers.py
+++ b/custom_components/extended_openai_conversation/helpers.py
@@ -47,7 +47,13 @@ from homeassistant.helpers.script import Script
 from homeassistant.helpers.template import Template
 import homeassistant.util.dt as dt_util
 
-from .const import CONF_PAYLOAD_TEMPLATE, DOMAIN, EVENT_AUTOMATION_REGISTERED
+from .const import (
+    CONF_PAYLOAD_TEMPLATE,
+    DEFAULT_TOKEN_PARAM,
+    DOMAIN,
+    EVENT_AUTOMATION_REGISTERED,
+    MODEL_TOKEN_PARAMETER_SUPPORT,
+)
 from .exceptions import (
     CallServiceError,
     EntityNotExposed,
@@ -75,6 +81,15 @@ def is_azure_url(base_url: str | None) -> bool:
     if base_url and re.search(AZURE_DOMAIN_PATTERN, base_url):
         return True
     return False
+
+
+def get_token_param_for_model(model: str) -> str:
+    """Return the token parameter name for a model."""
+    model_lower = model.lower()
+    for entry in MODEL_TOKEN_PARAMETER_SUPPORT:
+        if re.search(entry["pattern"], model_lower):
+            return entry["token_param"]
+    return DEFAULT_TOKEN_PARAM
 
 
 def convert_to_template(

--- a/custom_components/extended_openai_conversation/services.py
+++ b/custom_components/extended_openai_conversation/services.py
@@ -33,7 +33,7 @@ from .const import (
     DOMAIN,
     SERVICE_QUERY_IMAGE,
 )
-from .helpers import get_authenticated_client
+from .helpers import get_authenticated_client, get_token_param_for_model
 
 QUERY_IMAGE_SCHEMA = vol.Schema(
     {
@@ -94,18 +94,8 @@ async def async_setup_services(hass: HomeAssistant, config: ConfigType) -> None:
 
             client = entry.runtime_data
 
-            # Determine which token parameter to use based on model
-            # Newer models (gpt-4o, gpt-5, o1, o3, etc.) require max_completion_tokens
-            model_lower = model.lower()
-            use_new_token_param = any(
-                model_lower.startswith(prefix) or f"-{prefix}" in model_lower
-                for prefix in ("gpt-4o", "gpt-5", "o1", "o3", "o4")
-            )
-            token_kwargs = (
-                {"max_completion_tokens": call.data["max_tokens"]}
-                if use_new_token_param
-                else {"max_tokens": call.data["max_tokens"]}
-            )
+            token_param = get_token_param_for_model(model)
+            token_kwargs = {token_param: call.data["max_tokens"]}
 
             response = await client.chat.completions.create(
                 model=model,


### PR DESCRIPTION
### Motivation
Improve compatibility across OpenAI GPT model variants by avoiding parameters that some models reject (e.g., top_p).

Replace hardcoded, scattered model checks with centralized, parameter-based capability rules.

Ensure token-parameter selection (max_completion_tokens vs max_tokens) is consistent across the integration.

### Description
Added a centralized model capability map for unsupported parameters (e.g., omit top_p for gpt-5-mini/gpt-5-nano) so requests align with model requirements.

Moved token-parameter selection into a shared parameter-based lookup (support map + helper), replacing inline decision trees in multiple call sites.

Applied the shared logic in both conversation and image-query flows to keep model handling consistent across the integration.

Kept constants in const.py and helper logic in helpers.py to preserve clean separation of configuration values vs. behavior.

### Made with AI
Coded with Codex