### PR TITLE
Fix composite function consuming unnecessary contexts

### DIFF
--- a/custom_components/extended_openai_conversation/helpers.py
+++ b/custom_components/extended_openai_conversation/helpers.py
@@ -714,16 +714,17 @@ class CompositeFunctionExecutor(FunctionExecutor):
     ):
         config = function
         sequence = config["sequence"]
+        new_arguments = arguments.copy()
 
         for executor_config in sequence:
             function_executor = get_function_executor(executor_config["type"])
             result = await function_executor.execute(
-                hass, executor_config, arguments, llm_context, exposed_entities
+                hass, executor_config, new_arguments, llm_context, exposed_entities
             )
 
             response_variable = executor_config.get("response_variable")
             if response_variable:
-                arguments[response_variable] = result
+                new_arguments[response_variable] = result
 
         return result
 


### PR DESCRIPTION
## Objective
- Fix "composite" function consuming unnecessary context

## Example

As Is | To Be
--|--
<img width="597" height="848" alt="스크린샷 2026-01-11 오전 11 30 23" src="https://github.com/user-attachments/assets/6e5a132a-d34e-4826-a180-0604ef93438d" /> | <img width="592" height="663" alt="스크린샷 2026-01-11 오전 11 25 34" src="https://github.com/user-attachments/assets/bff23554-1ee8-45f3-84ad-f735f0d33f9e" />


```yaml
- spec:
    name: get_calendar_events_between
    description: Get calendar events between two datetimes.
    parameters:
      type: object
      properties:
        start_date_time:
          type: string
          description: The start date time in '%Y-%m-%dT%H:%M:%S%z' format
        end_date_time:
          type: string
          description: The end date time in '%Y-%m-%dT%H:%M:%S%z' format
      required:
      - start_date_time
      - end_date_time
  function:
    type: composite
    sequence:
      - type: script
        sequence:
          - service: calendar.get_events
            data:
              start_date_time: "{{start_date_time}}"
              end_date_time: "{{end_date_time}}"
            target:
              entity_id: calendar.test
            response_variable: _function_result
        response_variable: calendar_result
      - type: template
        value_template: "{{calendar_result}}"
```