### PR TITLE
Fix default prompt

### DIFF
--- a/custom_components/extended_openai_conversation/const.py
+++ b/custom_components/extended_openai_conversation/const.py
@@ -78,9 +78,11 @@ For smart home interactions, follow this decision flow strictly:
 
 5. State reference in confirmation questions
    When asking for confirmation:
-   - For numeric states: Always mention the current value to provide context
-   - For binary states: Omit the current state as the proposed action implies the current state
-   - Keep confirmation questions concise while providing necessary context
+   - Determine whether to include specific numeric values based on everyday familiarity:
+     * If the unit or value is something people routinely use in daily conversation and can intuitively understand without specialized knowledge, include the number
+     * If the unit is technical, abstract, or rarely discussed in everyday settings, use relative descriptive language instead without mentioning specific values
+   - For binary states: Omit the current state as the proposed action implies it
+   - Keep confirmation questions concise and natural
    - Propose a single concrete action and await explicit user approval
 
 When referring to the smart home state,

--- a/examples/prompt/annoying/README.md
+++ b/examples/prompt/annoying/README.md
@@ -10,7 +10,7 @@ A list of available devices in this smart home:
 
 ```csv
 entity_id,name,state,aliases
-{% for entity in exposed_entities -%}
+{% for entity in extended_openai.exposed_entities() -%}
 {{ entity.entity_id }},{{ entity.name }},{{entity.state}},{{entity.aliases | join('/')}}
 {% endfor -%}
 ```

--- a/examples/prompt/area/README.md
+++ b/examples/prompt/area/README.md
@@ -21,7 +21,7 @@ Current Area: {{area_id(current_device_id)}}
 Available Devices:
 ```csv
 entity_id,name,state,area_id,aliases
-{% for entity in exposed_entities -%}
+{% for entity in extended_openai.exposed_entities() -%}
 {{ entity.entity_id }},{{ entity.name }},{{ entity.state }},{{area_id(entity.entity_id)}},{{entity.aliases | join('/')}}
 {% endfor -%}
 ```
@@ -52,7 +52,7 @@ Current Area: {{area_name(current_device_id)}}
 
 An overview of the areas and the available devices:
 {%- set area_entities = namespace(mapping={}) %}
-{%- for entity in exposed_entities %}
+{%- for entity in extended_openai.exposed_entities() %}
     {%- set current_area_id = area_id(entity.entity_id) or "etc" %}
     {%- set entities = (area_entities.mapping.get(current_area_id) or []) + [entity] %}
     {%- set area_entities.mapping = dict(area_entities.mapping, **{current_area_id: entities}) -%}

--- a/examples/prompt/with_attributes/README.md
+++ b/examples/prompt/with_attributes/README.md
@@ -52,7 +52,7 @@ Current Time: {{now()}}
 Available Devices:
 ```csv
 entity_id,name,state,aliases,attributes
-{% for entity in exposed_entities -%}
+{% for entity in extended_openai.exposed_entities() -%}
 {{ entity.entity_id }},{{ entity.name }},{{ entity.state }},{{entity.aliases | join('/')}},{{get_exposed_attributes(entity.entity_id)}}
 {% endfor -%}
 ```


### PR DESCRIPTION
## Objective
- Use numeric unit of measurements only when necessary (people uses it in everyday language).
  - do: make it cooler?
  - don't : change color temperature to 5000 kelvin?


## Example
### Not Changed
<img width="300" src="https://github.com/user-attachments/assets/dfa926d8-ffa1-456c-8d99-edcba15e36bf" />

### Changed
Environment | As Is | To Be
--|--|--
brightness 50% | <img width="485" height="484" src="https://github.com/user-attachments/assets/fabee7a9-0988-4361-9dbf-4724990d3ce0" /> | <img width="487" height="488"  src="https://github.com/user-attachments/assets/e717686e-f043-486b-8379-0a6da55223c0" />
brightness 100% | <img width="487" height="488"  src="https://github.com/user-attachments/assets/617e5eef-2566-4dc0-8a5b-2fc1b051827e" /> | <img width="487" height="487" src="https://github.com/user-attachments/assets/ff42df62-3fb7-425c-b20b-bad52e912028" />