### PR TITLE
Sync openai and HA version with core

### DIFF
--- a/custom_components/extended_openai_conversation/manifest.json
+++ b/custom_components/extended_openai_conversation/manifest.json
@@ -19,7 +19,7 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/jekalmin/extended_openai_conversation/issues",
   "requirements": [
-    "openai~=2.8.0"
+    "openai~=2.15.0"
   ],
   "version": "3.0.0"
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
   "name": "extended_openai_conversation",
   "render_readme": true,
-  "homeassistant": "2025.12.0b0"
+  "homeassistant": "2026.2.0b0"
 }


### PR DESCRIPTION
## Link
- #396

## Changes

Updated the `openai` dependency in `manifest.json` and the minimum Home Assistant version in `hacs.json` to match the official `openai_conversation` component in Home Assistant 2026.2.0.

---
*PR created automatically by Jules for task [1705103767426621127](https://jules.google.com/task/1705103767426621127) started by @jekalmin*