### PR TITLE
Sync openai and Home Assistant versions

### DIFF
--- a/custom_components/extended_openai_conversation/manifest.json
+++ b/custom_components/extended_openai_conversation/manifest.json
@@ -18,7 +18,7 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/jekalmin/extended_openai_conversation/issues",
   "requirements": [
-    "openai~=2.8.0"
+    "openai~=2.15.0"
   ],
   "version": "2.0.1"
 }

--- a/custom_components/extended_openai_conversation/strings.json
+++ b/custom_components/extended_openai_conversation/strings.json
@@ -36,7 +36,7 @@
           "context_truncate_strategy": "Context truncation strategy when exceeded threshold"
         },
         "data_description": {
-          "use_tools": "Whether to use tool calling or function calling in the conversation. If disabled, function calling will be used (see https://platform.openai.com/docs/guides/function-calling)"
+          "use_tools": "Whether to use tool calling or function calling in the conversation. If disabled, function calling will be used."
         }
       }
     }

--- a/custom_components/extended_openai_conversation/translations/en.json
+++ b/custom_components/extended_openai_conversation/translations/en.json
@@ -42,7 +42,7 @@
                         "context_truncate_strategy": "Context truncation strategy when exceeded threshold"
                     },
                     "data_description": {
-                        "use_tools": "Whether to use tool calling or function calling in the conversation. If disabled, function calling will be used (see https://platform.openai.com/docs/guides/function-calling)"
+                        "use_tools": "Whether to use tool calling or function calling in the conversation. If disabled, function calling will be used."
                     }
                 }
             }

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
   "name": "extended_openai_conversation",
   "render_readme": true,
-  "homeassistant": "2025.12.0b0"
+  "homeassistant": "2026.2.0b0"
 }


### PR DESCRIPTION
## Link
- #396

## Changes

This change synchronizes the `openai` dependency version and the minimum Home Assistant version for the `extended_openai_conversation` custom component with the official `openai_conversation` component in Home Assistant Core.

Key changes:
- `manifest.json`: Updated `openai` from `~=2.8.0` to `~=2.15.0`.
- `hacs.json`: Updated minimum Home Assistant version from `2025.12.0b0` to `2026.2.0b0`.

These updates ensure compatibility with the latest versions used in the official Home Assistant integration.

---
*PR created automatically by Jules for task [11251974581943013131](https://jules.google.com/task/11251974581943013131) started by @jekalmin*