### PR TITLE
Add skills

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,90 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Extended OpenAI Conversation is a Home Assistant custom component that extends the built-in OpenAI Conversation integration. It adds a skills system, template functions, bash execution, file operations, AI Task entities, vision support, and multi-provider support (OpenAI, Azure OpenAI, compatible servers).
+
+## Commands
+
+### Lint & Format
+```bash
+ruff check custom_components/
+ruff format --check custom_components/
+# Auto-fix:
+ruff check --fix custom_components/
+ruff format custom_components/
+```
+
+### Type Check
+```bash
+mypy custom_components/extended_openai_conversation
+```
+
+### Tests
+```bash
+# All tests with coverage
+pytest tests/ -v --timeout=30 --cov=custom_components/extended_openai_conversation --cov-report=term-missing
+
+# Single test file
+pytest tests/function_executors/test_native.py -v
+
+# Single test
+pytest tests/function_executors/test_native.py::test_function_name -v
+```
+
+### Dev Setup
+```bash
+pip install -e ".[dev]"
+pip install -r requirements_test.txt
+```
+
+CI dynamically fetches dependency versions from HA core's dev branch (openai, hassil, beautifulsoup4, etc.) and tests against both stable and dev Home Assistant.
+
+## Architecture
+
+All source lives under `custom_components/extended_openai_conversation/`.
+
+### Entry Point & Platforms
+`__init__.py` sets up the OpenAI API client (`AsyncClient` or `AsyncAzureOpenAI`) and registers two platforms:
+- **conversation** (`conversation.py`, `entity.py`) — `ExtendedOpenAIAgentEntity` handles user messages via `async_process()`: builds system prompt with exposed entities + skills, calls OpenAI API with tools, executes tool calls through FunctionExecutors, iterates until completion.
+- **ai_task** (`ai_task.py`) — `ExtendedOpenAITaskEntity` handles background AI tasks with structured output (JSON schema), no tool calling.
+
+### Function Executors (`helpers.py`)
+Abstract `FunctionExecutor` base with implementations: `native` (HA services), `template` (Jinja2), `script` (HA scripts), `rest` (HTTP), `scrape` (BeautifulSoup), `bash`, `read_file`, `write_file`, `edit_file`, `sqlite`, `composite` (chains multiple). Each is registered by type string and resolved at tool-call time.
+
+### Skills System (`skills.py`)
+`SkillManager` (singleton) discovers and loads skills from `config/extended_openai_conversation/skills/`. Each skill is a directory with a `SKILL.md` file (YAML frontmatter + markdown content). `SkillMdParser` handles parsing. Skills are lazy-loaded — only metadata is kept in memory until content is requested.
+
+### Config Flow (`config_flow.py`)
+`ConfigFlow` for initial setup (API key, base URL, provider). `ConfigSubentryFlow` for per-conversation and per-ai-task settings (model, tokens, temperature, prompt template, functions YAML, skills selection).
+
+### Services (`services.py`)
+`query_image` (vision API), `change_config` (runtime config updates), `reload_skills`, `download_skill` (from GitHub).
+
+### Security
+- Workspace restriction for file operations (default: `extended_openai_conversation/`)
+- Shell command deny patterns (rm -rf, format, etc.)
+- File size limits (1 MB), bash timeout (300s), shell output limit (10,000 chars)
+
+## Test Structure
+
+Tests use `pytest` with `pytest-asyncio` and `pytest-homeassistant-custom-component`. All tests are async (`asyncio_mode = "auto"` in pyproject.toml).
+
+```
+tests/
+├── conftest.py              # Fixtures: hass mock, llm_context, exposed_entities, temp_db_path
+├── helpers.py               # Test utilities
+├── fixtures/                # Test data (functions YAML, mock responses)
+└── function_executors/      # One test file per executor type
+```
+
+## Key Conventions
+
+- Python 3.14+, HA minimum 2026.2.0b0
+- Ruff rules: E, W, F, I, UP, RUF, B, SIM (E501 and B008 ignored)
+- Import aliases enforced: `voluptuous` → `vol`, `homeassistant.helpers.config_validation` → `cv`
+- All I/O is async; use `async_add_executor_job()` for sync code
+- Custom exceptions in `exceptions.py` (EntityNotFound, CallServiceError, TokenLengthExceededError, etc.)
+- System prompt uses Jinja2 templates with context: `ha_name`, `exposed_entities`, `current_device_id`, `user_input`, `skills`

--- a/README.md
+++ b/README.md
@@ -3,6 +3,15 @@ This is custom component of Home Assistant.
 
 Derived from [OpenAI Conversation](https://www.home-assistant.io/integrations/openai_conversation/) with some new features such as call-service.
 
+## Changelog
+
+| Version       | Date    | Changes                                                            |
+|---------------|---------|--------------------------------------------------------------------|
+| `3.0.0-beta8` | 2026-02 | Add skills support, change default system prompt                   |
+| `3.0.0-beta5` | 2026-01 | Add AI Task entity, change default system prompt                   |
+| `3.0.0-beta4` | 2026-01 | Reasoning model support (GPT-5, o3)                                |
+| `3.0.0-beta2` | 2026-01 | exposed_entities available in template in developer tools |
+
 ## Additional Features
 - Ability to call service of Home Assistant
 - Ability to create automation
@@ -51,6 +60,25 @@ https://github.com/jekalmin/extended_openai_conversation/assets/2917984/04b93aa6
 
 ### 5. Play Netflix 
 https://github.com/jekalmin/extended_openai_conversation/assets/2917984/64ba656e-3ae7-4003-9956-da71efaf06dc
+
+## Skills
+Skills are reusable AI capabilities that can be enabled per conversation. Each skill provides specialized knowledge and instructions to the AI agent.
+
+Skills are loaded from `<config directory>/extended_openai_conversation/skills/` directory. You can download skills from the repository or create your own.
+
+### Using Skills
+1. Download a skill using the service:
+   ```yaml
+   service: extended_openai_conversation.download_skill
+   data:
+     skill_name: crypto
+   ```
+
+2. Enable skills through Options:
+   - Go to Settings > Voice Assistants > Edit Assistant > Options
+   - Select skills to enable from the list
+
+For detailed information about creating and managing skills, see [Skills Documentation](https://github.com/jekalmin/extended_openai_conversation/tree/develop/examples/skills).
 
 ## Configuration
 ### Options

--- a/custom_components/extended_openai_conversation/__init__.py
+++ b/custom_components/extended_openai_conversation/__init__.py
@@ -30,7 +30,7 @@ from .template import async_setup_templates, async_unload_templates
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS = [Platform.CONVERSATION, Platform.AI_TASK]
+PLATFORMS = [Platform.AI_TASK, Platform.CONVERSATION]
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
 type ExtendedOpenAIConfigEntry = ConfigEntry[AsyncClient]

--- a/custom_components/extended_openai_conversation/config_flow.py
+++ b/custom_components/extended_openai_conversation/config_flow.py
@@ -49,6 +49,7 @@ from .const import (
     CONF_REASONING_EFFORT,
     CONF_SERVICE_TIER,
     CONF_SHORTEN_TOOL_CALL_ID,
+    CONF_SKILLS,
     CONF_SKIP_AUTHENTICATION,
     CONF_TEMPERATURE,
     CONF_TOP_P,
@@ -78,6 +79,7 @@ from .const import (
     SERVICE_TIER_OPTIONS,
 )
 from .helpers import get_authenticated_client, get_model_config
+from .skills import SkillManager
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -221,6 +223,7 @@ class ExtendedOpenAISubentryFlowHandler(ConfigSubentryFlow):
 
     options: dict[str, Any]
     _temp_data: dict[str, Any] | None = None
+    _available_skills: list[dict[str, Any]] | None = None
 
     @property
     def _is_new(self) -> bool:
@@ -249,6 +252,10 @@ class ExtendedOpenAISubentryFlowHandler(ConfigSubentryFlow):
         if self._get_entry().state != ConfigEntryState.LOADED:
             return self.async_abort(reason="entry_not_loaded")
 
+        # Load available skills
+        if self._available_skills is None:
+            self._available_skills = await self._async_get_skills()
+
         if user_input is not None:
             # Check if advanced options is enabled
             if user_input.get(CONF_ADVANCED_OPTIONS, False):
@@ -271,7 +278,7 @@ class ExtendedOpenAISubentryFlowHandler(ConfigSubentryFlow):
                 data=user_input,
             )
 
-        schema = self.openai_config_option_schema(self.options)
+        schema = self.openai_config_option_schema(self.options, self._available_skills)
 
         if self._is_new:
             schema = {
@@ -380,10 +387,29 @@ class ExtendedOpenAISubentryFlowHandler(ConfigSubentryFlow):
             ),
         )
 
-    def openai_config_option_schema(self, options: dict[str, Any]) -> dict:
+    async def _async_get_skills(self) -> list[dict[str, Any]]:
+        """Load available skills using SkillManager."""
+        skill_manager = await SkillManager.async_get_instance(self.hass)
+        return [
+            {
+                "name": skill.name,
+                "description": skill.description,
+            }
+            for skill in skill_manager.get_all_skills()
+        ]
+
+    def openai_config_option_schema(
+        self, options: dict[str, Any], skills: list[dict[str, Any]] | None = None
+    ) -> dict:
         """Return a schema for OpenAI completion options."""
-        # Basic schema - shown on initial form
-        schema = {
+        # If creating a new subentry and no skills in options, default to all loaded skills
+        default_skills: list[str] = []
+        if self._is_new and CONF_SKILLS not in options and skills:
+            default_skills = [skill["name"] for skill in skills]
+
+        current_skills = options.get(CONF_SKILLS, default_skills)
+
+        schema: dict = {
             vol.Optional(
                 CONF_PROMPT,
                 default=DEFAULT_PROMPT,
@@ -400,6 +426,19 @@ class ExtendedOpenAISubentryFlowHandler(ConfigSubentryFlow):
                 CONF_MAX_FUNCTION_CALLS_PER_CONVERSATION,
                 default=DEFAULT_MAX_FUNCTION_CALLS_PER_CONVERSATION,
             ): int,
+            vol.Optional(CONF_SKILLS, default=current_skills): SelectSelector(
+                SelectSelectorConfig(
+                    options=[
+                        SelectOptionDict(
+                            value=skill["name"],
+                            label=skill["name"],
+                        )
+                        for skill in (skills or [])
+                    ],
+                    mode=SelectSelectorMode.DROPDOWN,
+                    multiple=True,
+                )
+            ),
             vol.Optional(
                 CONF_FUNCTIONS,
                 default=DEFAULT_CONF_FUNCTIONS_STR,
@@ -425,6 +464,14 @@ class ExtendedOpenAISubentryFlowHandler(ConfigSubentryFlow):
                 default=DEFAULT_ADVANCED_OPTIONS,
             ): BooleanSelector(),
         }
+
+        # Remove skills field if no skills available
+        if not skills:
+            schema = {
+                key: value
+                for key, value in schema.items()
+                if not (isinstance(key, vol.Optional) and key.schema == CONF_SKILLS)
+            }
 
         return schema
 

--- a/custom_components/extended_openai_conversation/const.py
+++ b/custom_components/extended_openai_conversation/const.py
@@ -22,100 +22,58 @@ EVENT_AUTOMATION_REGISTERED = "automation_registered_via_extended_openai_convers
 EVENT_CONVERSATION_FINISHED = "extended_openai_conversation.conversation.finished"
 
 CONF_PROMPT = "prompt"
-DEFAULT_PROMPT = """You are a voice assistant for Home Assistant.
+DEFAULT_PROMPT = """You are a helpful AI voice assistant of Home Assistant that controls a real home.
+Your goal is to proactively improve the user's comfort.
 
-Answer in plain text only.
-Respond naturally as a voice assistant.
-Prefer a single sentence; use up to 2-3 sentences only when truly necessary.
-Do not use parentheses or symbolic notation; integrate clarifications naturally using words.
+## Environment State
+- Current Time: {{now()}}
+- Current Area: {{area_id(current_device_id)}}
 
-For smart home interactions, follow this decision flow strictly:
+## Workspace
+Your workspace is at: {{extended_openai.working_directory()}}
 
-0. Action classification
-   Distinguish between two types of actions:
-   A. Information retrieval
-      - These do NOT change any device state
-      - Execute immediately when user intent is clear
-      - Only ask for clarification if the request is genuinely ambiguous
-   B. State-changing actions
-      - These DO change device state
-      - Execute immediately when user explicitly specifies the device and the exact action with clear values
-      - Require confirmation only when the request is ambiguous or lacks specific values
-      - If you have already proposed an action and the user responds with a specification or refinement, treat this as explicit confirmation and execute immediately
+## Guidelines
+- Answer in plain text only.
+- No symbols or parentheses
+- Ask for clarification when the request is ambiguous
+- Use tools to help accomplish tasks
+- Prefer one sentence
 
-1. Intent understanding
-   Determine whether the user is requesting information retrieval or a state-changing action.
-   Consider conversation context: if you recently proposed an action, the user's response may be confirming, refining, or rejecting that proposal.
+## Personality
+- Helpful and friendly
+- Concise and to the point
+- Curious and eager to learn
 
-2. Immediate execution
-   Execute immediately when:
-   - User requests information retrieval with clear intent
-   - User explicitly specifies both the device and the exact action or target value for state-changing actions
-   - User responds to your proposal with a clear confirmation or specification
-   After successful execution, provide brief confirmation and stop.
+## Behavior Policy
+- If the user explicitly names a device and action, execute it directly.
+- Otherwise, infer the user's goal and select the most likely target entity, preferring primary environmental controls. Use get_attributes to check adjustable state values alone is not sufficient.
+- If the selected entity is already at its limit, evaluate the next most likely entity. Repeat until a viable adjustment is found or all candidates are exhausted.
+- Ask user a minimum adjustment proposal about selected entity. If no entity can further improve the situation, inform the user that conditions are already optimal.
 
-3. Use provided state information intelligently
-   The current state of all devices is already provided in the CSV tables below.
-   For information available in the provided CSV:
-   - Always use this information directly
-   - Do NOT use tools to retrieve information that is already provided
-   For information NOT available in the provided CSV:
-   - If your response requires additional data beyond what is provided in the CSV, use available tools to retrieve that information
-   - Only retrieve additional information when necessary
-
-4. Context-aware proposal logic
-   When the user's intent requires clarification or lacks specific values:
-   a) Examine the provided CSV to identify devices relevant to the user's intent and their current states
-   b) Determine if the intent can be satisfied by changing device states shown in the CSV:
-      - If the required action is a simple state change but the target is ambiguous, propose a specific option
-   c) If the relevant devices are already in an appropriate state for the intent, or if proposing a meaningful adjustment requires knowing current parameter values:
-      - Retrieve the relevant adjustable parameters using available tools
-      - Use the current parameter values to propose a contextually appropriate adjustment
-      - The proposal should be relative to the current value, not an arbitrary target
-      - If parameters are already at their limits for the user's goal, inform the user
-   d) Propose one minimal and reasonable adjustment based on complete information
-   e) Always end with a confirmation question; never trigger execution
-
-5. State reference in confirmation questions
-   When asking for confirmation:
-   - Determine whether to include specific numeric values based on everyday familiarity:
-     * If the unit or value is something people routinely use in daily conversation and can intuitively understand without specialized knowledge, include the number
-     * If the unit is technical, abstract, or rarely discussed in everyday settings, use relative descriptive language instead without mentioning specific values
-   - For binary states: Omit the current state as the proposed action implies it
-   - Keep confirmation questions concise and natural
-   - Propose a single concrete action and await explicit user approval
-
-When referring to the smart home state,
-use only the information provided below or retrieved through allowed tools.
-
-For general knowledge questions not related to the home,
-answer truthfully using internal knowledge only.
-
-Current Time: {{now()}}
-Current Area: {{area_id(current_device_id)}}
-
-An overview of the areas and the available devices:
-{%- set area_entities = namespace(mapping={}) %}
-{%- for entity in extended_openai.exposed_entities() %}
-    {%- set current_area_id = area_id(entity.entity_id) or "etc" %}
-    {%- set entities = (area_entities.mapping.get(current_area_id) or []) + [entity] %}
-    {%- set area_entities.mapping = dict(area_entities.mapping, **{current_area_id: entities}) -%}
-{%- endfor %}
-
-{%- for current_area_id, entities in area_entities.mapping.items() %}
-
-  {%- if current_area_id == "etc" %}
-  Etc:
-  {%- else %}
-  {{area_name(current_area_id)}}:
-  {%- endif %}
+## Devices
+Available Devices:
 ```csv
-    entity_id,name,state,aliases
-    {%- for entity in entities %}
-    {{ entity.entity_id }},{{ entity.name }},{{ entity.state }},{{ entity.aliases | join('/') }}
-    {%- endfor %}
+entity_id,name,state,area_id,aliases
+{% for entity in extended_openai.exposed_entities() -%}
+{{ entity.entity_id }},{{ entity.name }},{{ entity.state }},{{area_id(entity.entity_id)}},{{entity.aliases | join('/')}}
+{% endfor -%}
 ```
-{%- endfor %}
+
+{%- if skills %}
+## Skills
+The following skills extend your capabilities. To use a skill, call load_skill with the skill name to read its instructions.
+When a skill file references a relative path, resolve it against the skill's location directory (e.g., skill at `/a/b/SKILL.md` references `scripts/run.py` → use `/a/b/scripts/run.py`) and always use the resulting absolute path in bash commands, as relative paths will fail.
+
+<available_skills>
+{%- for skill in skills %}
+  <skill>
+    <name>{{ skill.name }}</name>
+    <description>{{ skill.description }}</description>
+    <location>{{skill.path}}</location>
+  </skill>
+ {%- endfor %}
+</available_skills>
+{% endif %}
 
 {{user_input.extra_system_prompt | default('', true)}}
 """
@@ -140,7 +98,7 @@ DEFAULT_TOP_P = 1
 CONF_TEMPERATURE = "temperature"
 DEFAULT_TEMPERATURE = 0.5
 CONF_MAX_FUNCTION_CALLS_PER_CONVERSATION = "max_function_calls_per_conversation"
-DEFAULT_MAX_FUNCTION_CALLS_PER_CONVERSATION = 3
+DEFAULT_MAX_FUNCTION_CALLS_PER_CONVERSATION = 10
 CONF_SHORTEN_TOOL_CALL_ID = "shorten_tool_call_id"
 DEFAULT_SHORTEN_TOOL_CALL_ID = False
 CONF_FUNCTIONS = "functions"
@@ -148,7 +106,7 @@ DEFAULT_CONF_FUNCTIONS = [
     {
         "spec": {
             "name": "execute_services",
-            "description": "Execute service of devices in Home Assistant.",
+            "description": "Execute service in Home Assistant.",
             "parameters": {
                 "type": "object",
                 "properties": {
@@ -233,9 +191,50 @@ DEFAULT_CONF_FUNCTIONS = [
             "value_template": "```csv\nentity,attributes\n{%for entity in entity_id%}\n{{entity}},{{states[entity].attributes}}\n{%endfor%}\n```",
         },
     },
+    {
+        "spec": {
+            "name": "load_skill",
+            "description": "Load a file from a skill's directory.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "Skill name",
+                    },
+                    "file": {
+                        "type": "string",
+                        "description": "Relative file path within the skill directory",
+                    },
+                },
+                "required": ["name", "file"],
+            },
+        },
+        "function": {
+            "type": "read_file",
+            "path": "{{extended_openai.skill_dir(name)}}/{{file}}",
+        },
+    },
+    {
+        "spec": {
+            "name": "bash",
+            "description": "Execute a bash command in workspace.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "command": {
+                        "type": "string",
+                        "description": "Bash command to execute",
+                    },
+                },
+                "required": ["command"],
+            },
+        },
+        "function": {"type": "bash", "command": "{{command}}"},
+    },
 ]
 CONF_CONTEXT_THRESHOLD = "context_threshold"
-DEFAULT_CONTEXT_THRESHOLD = 13000
+DEFAULT_CONTEXT_THRESHOLD = 40000
 CONTEXT_TRUNCATE_STRATEGIES = [{"key": "clear", "label": "Clear All Messages"}]
 CONF_CONTEXT_TRUNCATE_STRATEGY = "context_truncate_strategy"
 DEFAULT_CONTEXT_TRUNCATE_STRATEGY = CONTEXT_TRUNCATE_STRATEGIES[0]["key"]
@@ -293,3 +292,47 @@ DEFAULT_AI_TASK_OPTIONS = {
     CONF_MAX_TOKENS: DEFAULT_MAX_TOKENS,
     CONF_ADVANCED_OPTIONS: DEFAULT_ADVANCED_OPTIONS,
 }
+
+# Skill System Constants
+CONF_SKILLS = "skills"
+DEFAULT_SKILLS_DIRECTORY = "skills"
+SKILL_FILE_NAME = "SKILL.md"
+
+# Skill Services
+SERVICE_RELOAD_SKILLS = "reload_skills"
+SERVICE_DOWNLOAD_SKILL = "download_skill"
+
+# GitHub repository for downloadable skills
+GITHUB_REPO_OWNER = "jekalmin"
+GITHUB_REPO_NAME = "extended_openai_conversation"
+GITHUB_SKILLS_BRANCH = "develop"
+GITHUB_SKILLS_PATH = "examples/skills"
+
+# Working Directory
+DEFAULT_WORKING_DIRECTORY = "extended_openai_conversation/"
+
+# File system and shell security settings
+SHELL_TIMEOUT = 300  # seconds
+SHELL_OUTPUT_LIMIT = 10000  # characters
+SHELL_DENY_PATTERNS = [
+    r"\brm\s+-r",  # Recursive delete
+    r"\brm\s+-rf",  # Force recursive delete
+    r"\bdel\s+/[fqs]",  # Windows delete with flags
+    r"\brmdir\s+/s",  # Windows recursive directory delete
+    r"\bformat\b",  # Disk format
+    r"\bmkfs\b",  # Make filesystem
+    r"\bdiskpart\b",  # Windows disk partition
+    r"\bdd\b",  # Disk duplicator
+    r"\bshutdown\b",  # System shutdown
+    r"\breboot\b",  # System reboot
+    r"\bpoweroff\b",  # Power off
+    r":\(\)\{.*:\|:.*\}",  # Fork bomb pattern
+]
+
+# File system limits
+FILE_READ_SIZE_LIMIT = 1024 * 1024  # 1 MB
+
+# Default allowed directories for file operations
+DEFAULT_ALLOWED_DIRS = [
+    DEFAULT_WORKING_DIRECTORY,  # extended_openai_conversation/
+]

--- a/custom_components/extended_openai_conversation/conversation.py
+++ b/custom_components/extended_openai_conversation/conversation.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from pathlib import Path
 from typing import Any, Literal
 
 from openai import OpenAIError
@@ -17,7 +18,6 @@ from homeassistant.components.conversation import (
     ConversationResult,
     async_get_chat_log,
 )
-from homeassistant.config_entries import ConfigSubentry
 from homeassistant.const import MATCH_ALL
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
@@ -29,14 +29,17 @@ from . import ExtendedOpenAIConfigEntry
 from .const import (
     CONF_FUNCTIONS,
     CONF_PROMPT,
+    CONF_SKILLS,
     DEFAULT_CONF_FUNCTIONS,
     DEFAULT_PROMPT,
+    DEFAULT_WORKING_DIRECTORY,
     DOMAIN,
     EVENT_CONVERSATION_FINISHED,
 )
 from .entity import ExtendedOpenAIBaseLLMEntity
 from .exceptions import FunctionLoadFailed, FunctionNotFound, InvalidFunction
 from .helpers import get_exposed_entities, get_function_executor
+from .skills import Skill, SkillManager
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -66,24 +69,33 @@ class ExtendedOpenAIAgentEntity(
 
     _attr_supports_streaming = True
     _attr_supported_features = ConversationEntityFeature.CONTROL
-
-    def __init__(
-        self,
-        entry: ExtendedOpenAIConfigEntry,
-        subentry: ConfigSubentry,
-    ) -> None:
-        """Initialize the agent."""
-        super().__init__(entry, subentry)
+    skill_manager: SkillManager
 
     @property
     def supported_languages(self) -> list[str] | Literal["*"]:
         """Return a list of supported languages."""
         return MATCH_ALL
 
+    @property
+    def skills(self) -> list[str]:
+        """Get the enabled skills list for this entity."""
+        return self.subentry.data.get(CONF_SKILLS, []) or []
+
     async def async_added_to_hass(self) -> None:
         """When entity is added to Home Assistant."""
         await super().async_added_to_hass()
         conversation.async_set_agent(self.hass, self.entry, self)
+
+        # Calculate skills directory based on working directory
+        working_dir = DEFAULT_WORKING_DIRECTORY
+        if Path(working_dir).is_absolute():
+            skills_dir = Path(working_dir) / "skills"
+        else:
+            skills_dir = Path(self.hass.config.config_dir) / working_dir / "skills"
+
+        self.skill_manager = await SkillManager.async_get_instance(
+            self.hass, user_skills_dir=str(skills_dir)
+        )
 
     async def async_will_remove_from_hass(self) -> None:
         """When entity will be removed from Home Assistant."""
@@ -141,7 +153,7 @@ class ExtendedOpenAIAgentEntity(
                 response=intent_response, conversation_id=user_input.conversation_id
             )
         except HomeAssistantError as err:
-            _LOGGER.error(err, exc_info=err)
+            _LOGGER.error("Error during conversation: %s", err, exc_info=True)
             intent_response = intent.IntentResponse(language=user_input.language)
             intent_response.async_set_error(
                 intent.IntentResponseErrorCode.UNKNOWN,
@@ -183,7 +195,7 @@ class ExtendedOpenAIAgentEntity(
         llm_context: llm.LLMContext,
         user_input: ConversationInput,
     ) -> str:
-        """Build system prompt with exposed entities."""
+        """Build system prompt with exposed entities and skills."""
         raw_prompt: str = self.subentry.data.get(CONF_PROMPT, DEFAULT_PROMPT)
 
         result = template.Template(raw_prompt, self.hass).async_render(
@@ -192,30 +204,42 @@ class ExtendedOpenAIAgentEntity(
                 "exposed_entities": exposed_entities,
                 "current_device_id": llm_context.device_id,
                 "user_input": user_input,
+                "skills": self._get_enabled_skills(),
             },
             parse_result=False,
         )
+
         return str(result)
+
+    def _get_enabled_skills(self) -> list[Skill]:
+        """Get enabled skills as list for template rendering."""
+        enabled_skill_names = self.skills
+        all_skills = self.skill_manager.get_all_skills()
+
+        return [s for s in all_skills if s.name in enabled_skill_names]
 
     def _get_exposed_entities(self) -> list[dict[str, Any]]:
         return get_exposed_entities(self.hass)
 
-    def _get_functions(self) -> list[dict]:
+    def _get_functions(self) -> list[dict[str, Any]]:
         """Get custom functions configuration."""
         try:
             function = self.subentry.data.get(CONF_FUNCTIONS)
-            result = yaml.safe_load(function) if function else DEFAULT_CONF_FUNCTIONS
+            result: list[dict[str, Any]] | None = (
+                yaml.safe_load(function) if function else DEFAULT_CONF_FUNCTIONS
+            )
             if result:
                 for setting in result:
                     if isinstance(setting, dict) and "function" in setting:
                         function_data = setting["function"]
                         if isinstance(function_data, dict) and "type" in function_data:
                             function_executor = get_function_executor(
-                                function_data["type"]
+                                str(function_data["type"])
                             )
                             setting["function"] = function_executor.to_arguments(
                                 function_data
                             )
+
             return result or []
         except (InvalidFunction, FunctionNotFound) as e:
             raise e

--- a/custom_components/extended_openai_conversation/entity.py
+++ b/custom_components/extended_openai_conversation/entity.py
@@ -56,7 +56,7 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 # Max number of back and forth with the LLM to generate a response
-MAX_TOOL_ITERATIONS = 10
+MAX_TOOL_ITERATIONS = 20
 
 
 def _shorten_tool_call_id(tool_call_id: str) -> str:
@@ -274,7 +274,7 @@ class ExtendedOpenAIBaseLLMEntity(Entity):
         for n_requests in range(MAX_TOOL_ITERATIONS):
             # Update tool_choice based on function call count
             # -1 means unlimited function calls
-            if tools and max_function_calls >= 0 and n_requests >= max_function_calls:
+            if tools and 0 <= max_function_calls <= n_requests:
                 tool_kwargs["tool_choice"] = "none"
 
             _LOGGER.info("Prompt for %s: %s", model, json.dumps(messages))

--- a/custom_components/extended_openai_conversation/helpers.py
+++ b/custom_components/extended_openai_conversation/helpers.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+import asyncio
 from datetime import timedelta
 from functools import partial
 import logging
 import os
+from pathlib import Path
 import re
 import sqlite3
 import time
@@ -26,10 +28,9 @@ from homeassistant.components import (
     rest,
     scrape,
 )
-from homeassistant.components.automation.config import _async_validate_config_item
 from homeassistant.components.homeassistant.exposed_entities import async_should_expose
 from homeassistant.components.recorder import history as recorder_history
-from homeassistant.components.script.config import SCRIPT_ENTITY_SCHEMA
+from homeassistant.components.script import config as script_config
 from homeassistant.config import AUTOMATION_CONFIG_PATH
 from homeassistant.const import (
     CONF_ATTRIBUTE,
@@ -53,12 +54,18 @@ import homeassistant.util.dt as dt_util
 
 from .const import (
     CONF_PAYLOAD_TEMPLATE,
+    DEFAULT_ALLOWED_DIRS,
     DEFAULT_MODEL_CONFIG,
     DEFAULT_TOKEN_PARAM,
+    DEFAULT_WORKING_DIRECTORY,
     DOMAIN,
     EVENT_AUTOMATION_REGISTERED,
+    FILE_READ_SIZE_LIMIT,
     MODEL_CONFIG_PATTERNS,
     MODEL_TOKEN_PARAMETER_SUPPORT,
+    SHELL_DENY_PATTERNS,
+    SHELL_OUTPUT_LIMIT,
+    SHELL_TIMEOUT,
 )
 from .exceptions import (
     CallServiceError,
@@ -245,7 +252,7 @@ async def get_authenticated_client(
 
 class FunctionExecutor(ABC):
     def __init__(self, data_schema: vol.Schema = vol.Schema({})) -> None:
-        """initialize function executor"""
+        """Initialize function executor"""
         self.data_schema = data_schema.extend({vol.Required("type"): str})
 
     def to_arguments(self, arguments: dict[str, Any]) -> dict[str, Any]:
@@ -287,12 +294,12 @@ class FunctionExecutor(ABC):
         llm_context: llm.LLMContext | None,
         exposed_entities: list[dict[str, Any]],
     ) -> Any:
-        """execute function"""
+        """Execute function"""
 
 
 class NativeFunctionExecutor(FunctionExecutor):
     def __init__(self) -> None:
-        """initialize native function"""
+        """Initialize native function"""
         super().__init__(vol.Schema({vol.Required("name"): str}))
 
     async def execute(
@@ -405,7 +412,7 @@ class NativeFunctionExecutor(FunctionExecutor):
         if isinstance(automation_config, dict):
             config.update(automation_config)
 
-        await _async_validate_config_item(hass, config, True, False)
+        await automation.config._async_validate_config_item(hass, config, True, False)
 
         automations = [config]
         with open(
@@ -552,8 +559,8 @@ class NativeFunctionExecutor(FunctionExecutor):
 
 class ScriptFunctionExecutor(FunctionExecutor):
     def __init__(self) -> None:
-        """initialize script function"""
-        super().__init__(SCRIPT_ENTITY_SCHEMA)
+        """Initialize script function"""
+        super().__init__(script_config.SCRIPT_ENTITY_SCHEMA)
 
     async def execute(
         self,
@@ -581,7 +588,7 @@ class ScriptFunctionExecutor(FunctionExecutor):
 
 class TemplateFunctionExecutor(FunctionExecutor):
     def __init__(self) -> None:
-        """initialize template function"""
+        """Initialize template function"""
         super().__init__(
             vol.Schema(
                 {
@@ -607,7 +614,7 @@ class TemplateFunctionExecutor(FunctionExecutor):
 
 class RestFunctionExecutor(FunctionExecutor):
     def __init__(self) -> None:
-        """initialize Rest function"""
+        """Initialize Rest function"""
         super().__init__(
             vol.Schema(rest.RESOURCE_SCHEMA).extend(
                 {
@@ -642,7 +649,7 @@ class RestFunctionExecutor(FunctionExecutor):
 
 class ScrapeFunctionExecutor(FunctionExecutor):
     def __init__(self) -> None:
-        """initialize Scrape function"""
+        """Initialize Scrape function"""
         super().__init__(
             scrape.COMBINED_SCHEMA.extend(
                 {
@@ -736,7 +743,7 @@ class ScrapeFunctionExecutor(FunctionExecutor):
 
 class CompositeFunctionExecutor(FunctionExecutor):
     def __init__(self) -> None:
-        """initialize composite function"""
+        """Initialize composite function"""
         super().__init__(
             vol.Schema(
                 {
@@ -784,7 +791,7 @@ class CompositeFunctionExecutor(FunctionExecutor):
 
 class SqliteFunctionExecutor(FunctionExecutor):
     def __init__(self) -> None:
-        """initialize sqlite function"""
+        """Initialize sqlite function"""
         super().__init__(
             vol.Schema(
                 {
@@ -872,6 +879,470 @@ class SqliteFunctionExecutor(FunctionExecutor):
             return result
 
 
+class FileFunctionExecutor(FunctionExecutor):
+    """Base class for file-related function executors."""
+
+    def get_working_dir(self, hass: HomeAssistant) -> Path:
+        """Get the default working directory for file operations.
+
+        Args:
+            hass: Home Assistant instance
+
+        Returns:
+            Path to the working directory
+        """
+        return Path(hass.config.config_dir) / DEFAULT_WORKING_DIRECTORY
+
+    def to_absolute_path(
+        self, hass: HomeAssistant, path: str, base_dir: Path | None = None
+    ) -> Path:
+        """Convert path to absolute path.
+
+        Args:
+            hass: Home Assistant instance
+            path: Path to convert (can be relative or absolute)
+            base_dir: Base directory for relative paths (defaults to config_dir)
+
+        Returns:
+            Absolute path
+        """
+        p = Path(path)
+        if p.is_absolute():
+            return p
+
+        if base_dir is None:
+            base_dir = Path(hass.config.config_dir)
+
+        return base_dir / p
+
+    def _resolve_path(
+        self,
+        hass: HomeAssistant,
+        path: str,
+        allow_dirs: list[str],
+    ) -> Path:
+        """Resolve path relative to working directory.
+
+        Args:
+            hass: Home Assistant instance
+            path: Path to resolve
+            allow_dirs: List of allowed directory paths (absolute)
+
+        Returns:
+            Resolved absolute path
+
+        Raises:
+            PermissionError: If path is not within allowed directories
+        """
+        workdir = self.get_working_dir(hass)
+        target = self.to_absolute_path(hass, path, workdir).resolve()
+
+        # Check against allowed directories (already resolved to absolute paths)
+        allowed = False
+        for allow_dir in allow_dirs:
+            allowed_path = Path(allow_dir).resolve()
+
+            if str(target).startswith(str(allowed_path)):
+                allowed = True
+                break
+
+        if not allowed:
+            raise PermissionError(
+                f"Access denied: path '{path}' is not in allowed directories"
+            )
+
+        return target
+
+    def _render_allow_dirs(
+        self,
+        hass: HomeAssistant,
+        allow_dirs: list[Template],
+        arguments: dict[str, Any],
+    ) -> list[str]:
+        """Render allow_dir templates.
+
+        Args:
+            hass: Home Assistant instance
+            allow_dirs: List of allow_dir templates from function config
+            arguments: Template arguments
+
+        Returns:
+            List of rendered directory paths
+
+        Always includes DEFAULT_ALLOWED_DIRS and adds custom allow_dir if specified.
+        """
+        # Always include default allowed directories (resolved to absolute paths)
+        all_allow_dirs = [
+            str(self.to_absolute_path(hass, d)) for d in DEFAULT_ALLOWED_DIRS
+        ]
+
+        # Add custom allow_dir if specified
+        if allow_dirs:
+            template_arguments = {
+                "config_dir": hass.config.config_dir,
+            }
+            template_arguments.update(arguments)
+            custom_dirs = [
+                template.async_render(template_arguments, parse_result=False)
+                for template in allow_dirs
+            ]
+            all_allow_dirs.extend(custom_dirs)
+
+        return all_allow_dirs
+
+
+class BashFunctionExecutor(FileFunctionExecutor):
+    """Execute shell commands with security controls."""
+
+    def __init__(self) -> None:
+        """Initialize bash function."""
+        schema = vol.Schema(
+            {
+                vol.Required("command"): cv.template,
+                vol.Optional("cwd"): cv.template,
+                vol.Optional("restrict_to_workspace", default=True): bool,
+                vol.Optional("allow_patterns"): vol.All(cv.ensure_list, [str]),
+            }
+        )
+        super().__init__(schema)
+
+    def _guard_command(
+        self,
+        command: str,
+        cwd: str | Path,
+        restrict_to_workspace: bool,
+        allow_patterns: list[str] | None = None,
+    ) -> None:
+        """Validate command against security policies.
+
+        Args:
+            command: Shell command to validate
+            cwd: Working directory where command will be executed
+            restrict_to_workspace: Whether to restrict paths to DEFAULT_ALLOWED_DIRS
+            allow_dirs: List of resolved absolute paths that are allowed (only used if restrict_to_workspace is True)
+            allow_patterns: Optional list of regex patterns for command allowlist
+        """
+        # Deny patterns check
+        for pattern in SHELL_DENY_PATTERNS:
+            if re.search(pattern, command, re.IGNORECASE):
+                raise ValueError(
+                    f"Command blocked by security policy: matches pattern '{pattern}'"
+                )
+
+        # Allow patterns check
+        if allow_patterns:
+            lower = command.lower()
+            if not any(re.search(p, lower) for p in allow_patterns):
+                raise ValueError("Command blocked: not in allowlist")
+
+        # Path restriction check when restrict_to_workspace is enabled
+        if restrict_to_workspace:
+            # Validate working directory is within allowed directories
+
+            # Block path traversal patterns
+            if "../" in command or "..\\" in command:
+                raise ValueError("Command blocked: path traversal detected")
+
+            # Extract and validate paths in command
+            win_paths = re.findall(r"[A-Za-z]:\\[^\\\"\' ]+", command)
+            posix_paths = re.findall(r"(?<!\w)/[^\s\"\']+", command)
+
+            for raw in win_paths + posix_paths:
+                try:
+                    p = Path(raw).resolve()
+                except Exception:
+                    continue
+
+                if cwd not in p.parents and p != cwd:
+                    raise ValueError(
+                        f"Command blocked by safety guard (path '{raw}' outside working dir).\nSet 'restrict_to_workspace: false' to allow command outside working directory."
+                    )
+
+    async def execute(
+        self,
+        hass: HomeAssistant,
+        function,
+        arguments,
+        llm_context: llm.LLMContext | None,
+        exposed_entities,
+    ):
+        """Execute shell command with security controls.
+
+        Args:
+            hass: Home Assistant instance
+            function: Function configuration containing command and optional cwd templates
+            arguments: Arguments for rendering templates and optional timeout
+            llm_context: LLM context (unused)
+            exposed_entities: Exposed entities (unused)
+
+        Returns:
+            Command output or error message
+        """
+        # Render command template
+        command_template = function.get("command")
+        command = command_template.async_render(arguments, parse_result=False)
+
+        # Render cwd template if provided
+        cwd_template = function.get("cwd")
+        if cwd_template:
+            cwd = Path(cwd_template.async_render(arguments, parse_result=False))
+        else:
+            cwd = self.get_working_dir(hass)
+
+        timeout = arguments.get("timeout", SHELL_TIMEOUT)
+        restrict_to_workspace = function.get("restrict_to_workspace", True)
+        allow_patterns = function.get("allow_patterns", [])
+
+        # Security validation
+        try:
+            self._guard_command(
+                command,
+                cwd=cwd,
+                restrict_to_workspace=restrict_to_workspace,
+                allow_patterns=allow_patterns,
+            )
+        except ValueError as err:
+            return {"error": str(err)}
+
+        try:
+            process = await asyncio.create_subprocess_shell(
+                command,
+                cwd=str(cwd),
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+
+            try:
+                stdout, stderr = await asyncio.wait_for(
+                    process.communicate(), timeout=timeout
+                )
+            except TimeoutError:
+                process.kill()
+                return {"error": f"Command timed out after {timeout} seconds"}
+
+            # Decode output with truncation
+            stdout_text = stdout.decode("utf-8", errors="replace")
+            stderr_text = stderr.decode("utf-8", errors="replace") if stderr else ""
+
+            # Truncate output if too large
+            if len(stdout_text) > SHELL_OUTPUT_LIMIT:
+                stdout_text = (
+                    stdout_text[:SHELL_OUTPUT_LIMIT]
+                    + "\n... (truncated, output too large)"
+                )
+            if len(stderr_text) > SHELL_OUTPUT_LIMIT:
+                stderr_text = (
+                    stderr_text[:SHELL_OUTPUT_LIMIT]
+                    + "\n... (truncated, output too large)"
+                )
+
+            result = {
+                "exit_code": process.returncode,
+                "stdout": stdout_text,
+            }
+
+            if stderr_text:
+                result["stderr"] = stderr_text
+
+        except Exception as e:
+            _LOGGER.error(e)
+            return {"error": str(e)}
+
+        return result
+
+
+class ReadFileFunctionExecutor(FileFunctionExecutor):
+    """Read file contents."""
+
+    def __init__(self) -> None:
+        """Initialize read file function."""
+        schema = vol.Schema(
+            {
+                vol.Required("path"): cv.template,
+                vol.Optional("allow_dir"): vol.All(cv.ensure_list, [cv.template]),
+            }
+        )
+        super().__init__(schema)
+
+    async def execute(
+        self,
+        hass: HomeAssistant,
+        function,
+        arguments,
+        llm_context: llm.LLMContext | None,
+        exposed_entities,
+    ):
+        """Read file contents."""
+        path_template = function.get("path")
+        path_str = path_template.async_render(arguments, parse_result=False)
+        allow_dirs = self._render_allow_dirs(
+            hass, function.get("allow_dir", []), arguments
+        )
+
+        try:
+            target_path = self._resolve_path(hass, path_str, allow_dirs)
+
+            if not target_path.exists():
+                return {"error": f"File not found: {path_str}"}
+
+            if not target_path.is_file():
+                return {"error": f"Not a file: {path_str}"}
+
+            # Check file size
+            file_size = target_path.stat().st_size
+            if file_size > FILE_READ_SIZE_LIMIT:
+                return {
+                    "error": f"File too large: {file_size} bytes (limit: {FILE_READ_SIZE_LIMIT})"
+                }
+
+            # Read file
+            content = await hass.async_add_executor_job(
+                partial(target_path.read_text, encoding="utf-8")
+            )
+
+        except Exception as e:
+            _LOGGER.error(e)
+            return {"error": str(e)}
+
+        return {"content": content, "size": file_size}
+
+
+class WriteFileFunctionExecutor(FileFunctionExecutor):
+    """Write content to file."""
+
+    def __init__(self) -> None:
+        """Initialize write file function."""
+        schema = vol.Schema(
+            {
+                vol.Required("path"): cv.template,
+                vol.Required("content"): cv.template,
+                vol.Optional("allow_dir"): vol.All(cv.ensure_list, [cv.template]),
+            }
+        )
+        super().__init__(schema)
+
+    async def execute(
+        self,
+        hass: HomeAssistant,
+        function,
+        arguments,
+        llm_context: llm.LLMContext | None,
+        exposed_entities,
+    ):
+        """Write content to file."""
+        path_template = function.get("path")
+        path_str = path_template.async_render(arguments, parse_result=False)
+        content_template = function.get("content")
+        content = content_template.async_render(arguments, parse_result=False)
+        allow_dirs = self._render_allow_dirs(
+            hass, function.get("allow_dir", []), arguments
+        )
+
+        try:
+            target_path = self._resolve_path(hass, path_str, allow_dirs)
+
+            # Create parent directories if needed
+            # await hass.async_add_executor_job(
+            #     partial(target_path.parent.mkdir, parents=True, exist_ok=True)
+            # )
+
+            # Write file
+            await hass.async_add_executor_job(
+                partial(target_path.write_text, content, encoding="utf-8")
+            )
+
+            bytes_written = len(content.encode("utf-8"))
+
+        except Exception as err:
+            _LOGGER.exception("File write error: %s", err)
+            return {"error": str(err)}
+
+        return {
+            "success": True,
+            "path": str(target_path),
+            "bytes_written": bytes_written,
+        }
+
+
+class EditFileFunctionExecutor(FileFunctionExecutor):
+    """Edit file with find-and-replace."""
+
+    def __init__(self) -> None:
+        """Initialize edit file function."""
+        schema = vol.Schema(
+            {
+                vol.Required("path"): cv.template,
+                vol.Required("old_text"): cv.template,
+                vol.Required("new_text"): cv.template,
+                vol.Optional("allow_dir"): vol.All(cv.ensure_list, [cv.template]),
+            }
+        )
+        super().__init__(schema)
+
+    async def execute(
+        self,
+        hass: HomeAssistant,
+        function,
+        arguments,
+        llm_context: llm.LLMContext | None,
+        exposed_entities,
+    ):
+        """Edit file with find-and-replace."""
+        path_template = function.get("path")
+        path_str = path_template.async_render(arguments, parse_result=False)
+        old_text_template = function.get("old_text")
+        old_text = old_text_template.async_render(arguments, parse_result=False)
+        new_text_template = function.get("new_text")
+        new_text = new_text_template.async_render(arguments, parse_result=False)
+        allow_dirs = self._render_allow_dirs(
+            hass, function.get("allow_dir", []), arguments
+        )
+
+        try:
+            target_path = self._resolve_path(hass, path_str, allow_dirs)
+
+            if not target_path.exists():
+                return {"error": f"File not found: {path_str}"}
+
+            if not target_path.is_file():
+                return {"error": f"Not a file: {path_str}"}
+
+            # Read current content
+            content = await hass.async_add_executor_job(
+                partial(target_path.read_text, encoding="utf-8")
+            )
+
+            # Check for text to replace
+            if old_text not in content:
+                return {"error": f"Text not found in file: {old_text[:50]}..."}
+
+            # Check for multiple occurrences
+            occurrence_count = content.count(old_text)
+            if occurrence_count > 1:
+                return {
+                    "error": f"Text appears {occurrence_count} times in file. "
+                    "Please provide more specific text to ensure single replacement."
+                }
+
+            # Perform replacement
+            new_content = content.replace(old_text, new_text, 1)
+
+            # Write back
+            await hass.async_add_executor_job(
+                partial(target_path.write_text, new_content, encoding="utf-8")
+            )
+
+        except Exception as e:
+            _LOGGER.error(e)
+            return {"error": str(e)}
+
+        return {
+            "success": True,
+            "path": str(target_path),
+            "replacements": 1,
+        }
+
+
 FUNCTION_EXECUTORS: dict[str, FunctionExecutor] = {
     "native": NativeFunctionExecutor(),
     "script": ScriptFunctionExecutor(),
@@ -880,4 +1351,8 @@ FUNCTION_EXECUTORS: dict[str, FunctionExecutor] = {
     "scrape": ScrapeFunctionExecutor(),
     "composite": CompositeFunctionExecutor(),
     "sqlite": SqliteFunctionExecutor(),
+    "bash": BashFunctionExecutor(),
+    "read_file": ReadFileFunctionExecutor(),
+    "write_file": WriteFileFunctionExecutor(),
+    "edit_file": EditFileFunctionExecutor(),
 }

--- a/custom_components/extended_openai_conversation/services.py
+++ b/custom_components/extended_openai_conversation/services.py
@@ -18,6 +18,7 @@ from homeassistant.core import (
 )
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_validation as cv, selector
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.typing import ConfigType
 
 from .const import (
@@ -28,7 +29,13 @@ from .const import (
     CONF_SKIP_AUTHENTICATION,
     DEFAULT_CONF_BASE_URL,
     DOMAIN,
+    GITHUB_REPO_NAME,
+    GITHUB_REPO_OWNER,
+    GITHUB_SKILLS_BRANCH,
+    GITHUB_SKILLS_PATH,
+    SERVICE_DOWNLOAD_SKILL,
     SERVICE_QUERY_IMAGE,
+    SERVICE_RELOAD_SKILLS,
 )
 from .helpers import get_authenticated_client, get_token_param_for_model
 
@@ -59,6 +66,14 @@ CHANGE_CONFIG_SCHEMA = vol.Schema(
         vol.Optional(CONF_ORGANIZATION): cv.string,
         vol.Optional(CONF_SKIP_AUTHENTICATION): cv.boolean,
         vol.Optional(CONF_API_PROVIDER): cv.string,
+    }
+)
+
+RELOAD_SKILLS_SCHEMA = vol.Schema({})
+
+DOWNLOAD_SKILL_SCHEMA = vol.Schema(
+    {
+        vol.Required("skill_name"): cv.string,
     }
 )
 
@@ -114,14 +129,14 @@ async def async_setup_services(hass: HomeAssistant, config: ConfigType) -> None:
             raise HomeAssistantError(f"Config entry {entry_id} not found")
 
         updates = {}
-        for key in [
+        for key in (
             CONF_API_KEY,
             CONF_BASE_URL,
             CONF_API_VERSION,
             CONF_ORGANIZATION,
             CONF_SKIP_AUTHENTICATION,
             CONF_API_PROVIDER,
-        ]:
+        ):
             if key in call.data:
                 updates[key] = call.data[key]
 
@@ -154,6 +169,105 @@ async def async_setup_services(hass: HomeAssistant, config: ConfigType) -> None:
 
         hass.config_entries.async_update_entry(entry, data=new_data)
 
+    async def reload_skills(call: ServiceCall) -> ServiceResponse:
+        """Reload skills from the user skill directory."""
+        from .skills import SkillManager
+
+        skill_manager = await SkillManager.async_get_instance(hass)
+        await skill_manager.async_load_skills()
+
+        return {
+            "loaded_skills": len(skill_manager.get_all_skills()),
+        }
+
+    async def download_skill(call: ServiceCall) -> ServiceResponse:
+        """Download a skill from the GitHub repository."""
+        from .skills import SkillManager
+
+        skill_name = call.data["skill_name"]
+        session = async_get_clientsession(hass)
+
+        # Fetch skill directory contents from GitHub API
+        api_url = (
+            f"https://api.github.com/repos/{GITHUB_REPO_OWNER}/{GITHUB_REPO_NAME}"
+            f"/contents/{GITHUB_SKILLS_PATH}/{skill_name}"
+            f"?ref={GITHUB_SKILLS_BRANCH}"
+        )
+
+        downloaded_files: list[str] = []
+
+        async def _download_directory(url: str, local_dir: Path) -> None:
+            """Recursively download a directory from GitHub."""
+            async with session.get(url) as resp:
+                if resp.status == 404:
+                    raise HomeAssistantError(
+                        f"Skill `{skill_name}` not found in repository"
+                    )
+                if resp.status != 200:
+                    raise HomeAssistantError(
+                        f"Failed to fetch skill from GitHub (HTTP {resp.status})"
+                    )
+                items = await resp.json()
+
+            if not isinstance(items, list):
+                raise HomeAssistantError(
+                    f"Unexpected response from GitHub for skill `{skill_name}`"
+                )
+
+            for item in items:
+                item_path = local_dir / item["name"]
+                if item["type"] == "file":
+                    # Download file content
+                    async with session.get(item["download_url"]) as file_resp:
+                        if file_resp.status != 200:
+                            raise HomeAssistantError(
+                                f"Failed to download `{item['path']}`"
+                            )
+                        content = await file_resp.read()
+
+                    await hass.async_add_executor_job(
+                        _write_file_sync, item_path, content
+                    )
+                    downloaded_files.append(str(item["path"]))
+                elif item["type"] == "dir":
+                    # Recurse into subdirectory
+                    await _download_directory(item["url"], item_path)
+
+        def _write_file_sync(file_path: Path, content: bytes) -> None:
+            """Write file content to disk (run in executor)."""
+            file_path.parent.mkdir(parents=True, exist_ok=True)
+            file_path.write_bytes(content)
+
+        # Determine target directory
+        skill_manager = await SkillManager.async_get_instance(hass)
+        target_dir = skill_manager.user_skills_dir / skill_name
+
+        _LOGGER.info("Downloading skill `%s` to %s", skill_name, target_dir)
+
+        try:
+            await _download_directory(api_url, target_dir)
+        except HomeAssistantError:
+            raise
+        except Exception as err:
+            raise HomeAssistantError(
+                f"Failed to download skill `{skill_name}`: {err}"
+            ) from err
+
+        # Reload skills after download
+        await skill_manager.async_load_skills()
+
+        _LOGGER.info(
+            "Successfully downloaded skill `%s` (%d files)",
+            skill_name,
+            len(downloaded_files),
+        )
+
+        return {
+            "skill_name": skill_name,
+            "downloaded_files": downloaded_files,
+            "target_directory": str(target_dir),
+        }
+
     hass.services.async_register(
         DOMAIN,
         SERVICE_QUERY_IMAGE,
@@ -167,6 +281,22 @@ async def async_setup_services(hass: HomeAssistant, config: ConfigType) -> None:
         "change_config",
         change_config,
         schema=CHANGE_CONFIG_SCHEMA,
+    )
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_RELOAD_SKILLS,
+        reload_skills,
+        schema=RELOAD_SKILLS_SCHEMA,
+        supports_response=SupportsResponse.ONLY,
+    )
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_DOWNLOAD_SKILL,
+        download_skill,
+        schema=DOWNLOAD_SKILL_SCHEMA,
+        supports_response=SupportsResponse.ONLY,
     )
 
 

--- a/custom_components/extended_openai_conversation/services.yaml
+++ b/custom_components/extended_openai_conversation/services.yaml
@@ -60,3 +60,16 @@ change_config:
             - openai
             - azure
           mode: dropdown
+download_skill:
+  name: Download skill
+  description: Download a skill from the GitHub repository and install it to the user skills directory. Available skills can be found at https://github.com/jekalmin/extended_openai_conversation/tree/develop/examples/skills
+  fields:
+    skill_name:
+      required: true
+      example: crypto
+      description: Name of the skill to download (e.g., crypto, weather, calendar)
+      selector:
+        text:
+reload_skills:
+  name: Reload skills
+  description: Reload all skills from the user skills directory to pick up changes or newly added skills

--- a/custom_components/extended_openai_conversation/skills.py
+++ b/custom_components/extended_openai_conversation/skills.py
@@ -1,0 +1,259 @@
+"""Skill management for the Extended OpenAI Conversation component."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import logging
+from pathlib import Path
+import re
+
+import yaml
+
+from homeassistant.core import HomeAssistant
+
+from .const import DEFAULT_SKILLS_DIRECTORY, DEFAULT_WORKING_DIRECTORY, SKILL_FILE_NAME
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class Skill:
+    """Represents a skill loaded from SKILL.md.
+
+    Only metadata (name, description) is loaded initially.
+    The full content (body) is loaded on-demand via load_skill function.
+    """
+
+    name: str  # Directory path used as identifier
+    description: str
+    path: Path  # Path to SKILL.md file
+
+    def __post_init__(self) -> None:
+        """Validate skill fields."""
+        if not self.name:
+            raise ValueError("Skill name is required")
+        if len(self.name) > 64:
+            raise ValueError("Skill name must be 64 characters or less")
+        if len(self.description) > 1024:
+            raise ValueError("Skill description must be 1024 characters or less")
+
+
+class SkillMdParser:
+    """Parser for SKILL.md files following Agent Skills standard."""
+
+    FRONTMATTER_PATTERN = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL)
+
+    @classmethod
+    def parse(
+        cls, content: str, skill_path: Path, skills_base_dir: Path
+    ) -> Skill | None:
+        """Parse SKILL.md content and return a Skill object.
+
+        Uses directory path as name for identification.
+        Parses frontmatter for description.
+        The body content is loaded on-demand via load_skill function.
+
+        Args:
+            content: Full content of SKILL.md file
+            skill_path: Path to the SKILL.md file
+            skills_base_dir: Base directory for skills (used to calculate relative path)
+
+        Returns:
+            Skill object with metadata, or None if parsing fails
+        """
+        match = cls.FRONTMATTER_PATTERN.match(content)
+        if not match:
+            _LOGGER.warning(
+                "Invalid SKILL.md format in %s: missing frontmatter", skill_path
+            )
+            return None
+
+        try:
+            frontmatter = yaml.safe_load(match.group(1))
+        except yaml.YAMLError as e:
+            _LOGGER.warning("Failed to parse YAML frontmatter in %s: %s", skill_path, e)
+            return None
+
+        if not isinstance(frontmatter, dict):
+            _LOGGER.warning("Invalid frontmatter format in %s", skill_path)
+            return None
+
+        description = frontmatter.get("description")
+
+        if not description:
+            _LOGGER.warning("Missing required field (description) in %s", skill_path)
+            return None
+
+        # Calculate relative directory path from skills base to use as name
+        skill_dir = skill_path.parent
+        try:
+            relative_path = skill_dir.relative_to(skills_base_dir)
+            name = str(relative_path)
+        except ValueError:
+            # Fallback to directory name if not relative to base
+            name = skill_dir.name
+
+        try:
+            return Skill(
+                name=name,
+                description=description,
+                path=skill_path,
+            )
+        except ValueError as e:
+            _LOGGER.warning("Invalid skill in %s: %s", skill_path, e)
+            return None
+
+    @classmethod
+    def extract_body(cls, content: str) -> str:
+        """Extract the body content after frontmatter.
+
+        Args:
+            content: Full content of SKILL.md file
+
+        Returns:
+            Body content (markdown after frontmatter)
+        """
+        match = cls.FRONTMATTER_PATTERN.match(content)
+        if not match:
+            return content
+
+        return content[match.end() :].strip()
+
+
+class SkillManager:
+    """Manages skills for the Extended OpenAI Conversation component.
+
+    Skills are loaded from the user skills directory.
+    Only metadata (name, description) is loaded initially for system prompt.
+    Full skill content is loaded on-demand via load_skill function.
+
+    This class is designed to be used as a singleton - it only handles
+    skill loading and reading. Enabled skills list is managed
+    per ConversationEntity via subentry.data[CONF_SKILLS].
+    """
+
+    _instance: SkillManager | None = None
+
+    def __init__(self, hass: HomeAssistant) -> None:
+        """Initialize the skill manager.
+
+        Args:
+            hass: Home Assistant instance
+        """
+        self._hass = hass
+        self._skills: dict[str, Skill] = {}  # key is skill name (directory path)
+        self._user_skills_dir: Path | None = None
+
+    @classmethod
+    async def async_get_instance(
+        cls, hass: HomeAssistant, user_skills_dir: str | None = None
+    ) -> SkillManager:
+        """Get or create the singleton instance and load skills.
+
+        Args:
+            hass: Home Assistant instance
+            user_skills_dir: Optional custom user skills directory path
+
+        Returns:
+            The singleton SkillManager instance with skills loaded
+        """
+        if cls._instance is None:
+            cls._instance = cls(hass)
+            if user_skills_dir:
+                cls._instance._user_skills_dir = Path(user_skills_dir)
+            await cls._instance.async_load_skills()
+        return cls._instance
+
+    @property
+    def user_skills_dir(self) -> Path:
+        """Get the user skills directory path."""
+        if self._user_skills_dir is None:
+            self._user_skills_dir = (
+                Path(self._hass.config.config_dir)
+                / DEFAULT_WORKING_DIRECTORY
+                / DEFAULT_SKILLS_DIRECTORY
+            )
+        return self._user_skills_dir
+
+    async def async_load_skills(self) -> None:
+        """Load all skills from the user skills directory.
+
+        Only loads metadata (frontmatter) from SKILL.md files.
+        """
+        self._skills.clear()
+
+        skills_data = await self._hass.async_add_executor_job(
+            self._load_skills_from_dir_sync, self.user_skills_dir
+        )
+
+        for skill_path, content in skills_data:
+            try:
+                skill = SkillMdParser.parse(content, skill_path, self.user_skills_dir)
+                if skill:
+                    self._skills[skill.name] = skill
+                    _LOGGER.debug(
+                        "Loaded skill: %s from %s",
+                        skill.name,
+                        skill_path,
+                    )
+            except Exception as e:
+                _LOGGER.exception(
+                    "Unexpected error loading skill from %s: %s", skill_path, e
+                )
+
+        _LOGGER.info("Loaded %d skills", len(self._skills))
+
+    def _load_skills_from_dir_sync(self, skills_dir: Path) -> list[tuple[Path, str]]:
+        """Load skill files synchronously from a specific directory (run in executor).
+
+        Args:
+            skills_dir: Path to the skills directory to load from
+
+        Returns:
+            List of tuples (skill_file_path, file_content)
+        """
+        results: list[tuple[Path, str]] = []
+
+        if not skills_dir.exists():
+            _LOGGER.debug("Skills directory does not exist: %s", skills_dir)
+            return results
+
+        if not skills_dir.is_dir():
+            _LOGGER.warning("Skills path is not a directory: %s", skills_dir)
+            return results
+
+        for skill_dir in skills_dir.iterdir():
+            if not skill_dir.is_dir():
+                continue
+
+            skill_file = skill_dir / SKILL_FILE_NAME
+            if not skill_file.exists():
+                _LOGGER.debug("No SKILL.md found in %s", skill_dir)
+                continue
+
+            try:
+                content = skill_file.read_text(encoding="utf-8")
+                results.append((skill_file, content))
+            except OSError as e:
+                _LOGGER.warning("Failed to read skill file %s: %s", skill_file, e)
+
+        return results
+
+    def get_skill(self, name: str) -> Skill | None:
+        """Get a skill by name (directory path).
+
+        Args:
+            name: The skill name (directory path)
+
+        Returns:
+            The skill if found, None otherwise
+        """
+        return self._skills.get(name)
+
+    def get_all_skills(self) -> list[Skill]:
+        """Get all loaded skills.
+
+        Returns:
+            List of all skills
+        """
+        return list(self._skills.values())

--- a/custom_components/extended_openai_conversation/strings.json
+++ b/custom_components/extended_openai_conversation/strings.json
@@ -33,6 +33,7 @@
             "model": "Completion Model",
             "prompt": "Prompt Template",
             "max_function_calls_per_conversation": "Maximum function calls per conversation",
+            "skills": "Skills",
             "functions": "Functions",
             "attach_username": "Attach Username to Message",
             "context_threshold": "Context Threshold",
@@ -150,6 +151,20 @@
           "description": "The API provider. (OpenAI or Azure)"
         }
       }
+    },
+    "download_skill": {
+      "name": "Download skill",
+      "description": "Download a skill from the GitHub repository to your skills directory.",
+      "fields": {
+        "skill_name": {
+          "name": "Skill name",
+          "description": "The name of the skill to download (e.g., crypto)"
+        }
+      }
+    },
+    "reload_skills": {
+      "name": "Reload skills",
+      "description": "Reload skills from the skills directory."
     }
   }
 }

--- a/custom_components/extended_openai_conversation/template.py
+++ b/custom_components/extended_openai_conversation/template.py
@@ -3,13 +3,15 @@
 from __future__ import annotations
 
 import logging
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.template import TemplateEnvironment
 
-from .const import DOMAIN
+from .const import DEFAULT_WORKING_DIRECTORY, DOMAIN
 from .helpers import get_exposed_entities
+from .skills import SkillManager
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -20,6 +22,8 @@ DATA_TEMPLATE_MANAGER = "template_manager"
 
 TEMPLATE_EXTENDED_OPENAI = "extended_openai"
 TEMPLATE_GET_ENTITIES = "exposed_entities"
+TEMPLATE_WORKING_DIRECTORY = "working_directory"
+TEMPLATE_SKILL_DIR = "skill_dir"
 
 
 async def async_setup_templates(hass: HomeAssistant) -> bool:
@@ -50,11 +54,42 @@ class ExtendedOpenAITemplateManager:
     def __init__(self, hass: HomeAssistant) -> None:
         """Initialize the template manager."""
         self.hass = hass
-        self._extended_openai = {TEMPLATE_GET_ENTITIES: self._get_exposed_entities}
+        self._extended_openai = {
+            TEMPLATE_GET_ENTITIES: self._get_exposed_entities,
+            TEMPLATE_WORKING_DIRECTORY: self._get_working_directory,
+            TEMPLATE_SKILL_DIR: self._get_skill_dir,
+        }
         self._original_init = None
 
     def _get_exposed_entities(self) -> list[dict[str, Any]]:
         return get_exposed_entities(self.hass)
+
+    def _get_working_directory(self) -> str:
+        """Get the absolute working directory path."""
+        working_dir = DEFAULT_WORKING_DIRECTORY
+        if Path(working_dir).is_absolute():
+            return str(Path(working_dir))
+        return str(Path(self.hass.config.config_dir) / working_dir)
+
+    def _get_skill_dir(self, name: str) -> str:
+        """Get the absolute directory path for a skill by name.
+
+        Args:
+            name: The skill name (e.g., 'crypto', 'skill-creator')
+
+        Returns:
+            Absolute path to the skill directory
+
+        Raises:
+            ValueError: If the skill is not found
+        """
+        manager = SkillManager._instance
+        if manager is None:
+            raise ValueError("SkillManager not initialized")
+        skill = manager.get_skill(name)
+        if skill is None:
+            raise ValueError(f"Skill not found: {name}")
+        return str(skill.path.parent)
 
     async def async_setup(self) -> None:
         """Set up the template functions."""

--- a/custom_components/extended_openai_conversation/translations/de.json
+++ b/custom_components/extended_openai_conversation/translations/de.json
@@ -33,6 +33,7 @@
                         "model": "Completion Model",
                         "prompt": "Prompt Vorlage",
                         "max_function_calls_per_conversation": "Maximale Anzahl an Funktionsaufrufen pro Konversation",
+                        "skills": "Skills",
                         "functions": "Funktionen",
                         "attach_username": "Benutzernamen mitgeben",
                         "context_threshold": "Context Threshold",
@@ -47,7 +48,11 @@
                         "temperature": "Temperatur",
                         "top_p": "Top P",
                         "reasoning_effort": "Reasoning effort",
-                        "service_tier": "Service tier"
+                        "service_tier": "Service tier",
+                        "shorten_tool_call_id": "Shorten tool call IDs"
+                    },
+                    "data_description": {
+                        "shorten_tool_call_id": "Required for Mistral AI cloud API compatibility. Enable only if your provider requires short (9-character) tool call IDs. Keep disabled for OpenAI and most other providers."
                     }
                 }
             }
@@ -73,7 +78,11 @@
                         "temperature": "Temperature",
                         "top_p": "Top P",
                         "reasoning_effort": "Reasoning effort",
-                        "service_tier": "Service tier"
+                        "service_tier": "Service tier",
+                        "shorten_tool_call_id": "Shorten tool call IDs"
+                    },
+                    "data_description": {
+                        "shorten_tool_call_id": "Required for Mistral AI cloud API compatibility. Enable only if your provider requires short (9-character) tool call IDs. Keep disabled for OpenAI and most other providers."
                     }
                 }
             }
@@ -142,6 +151,20 @@
                     "description": "The API provider. (OpenAI or Azure)"
                 }
             }
+        },
+        "download_skill": {
+            "name": "Download skill",
+            "description": "Download a skill from the GitHub repository to your skills directory. Available skills: https://github.com/jekalmin/extended_openai_conversation/tree/develop/examples/skills",
+            "fields": {
+                "skill_name": {
+                    "name": "Skill name",
+                    "description": "The name of the skill to download (e.g., crypto)"
+                }
+            }
+        },
+        "reload_skills": {
+            "name": "Reload skills",
+            "description": "Reload skills from the skills directory."
         }
     }
 }

--- a/custom_components/extended_openai_conversation/translations/el.json
+++ b/custom_components/extended_openai_conversation/translations/el.json
@@ -33,6 +33,7 @@
                         "model": "Μοντέλο Ολοκλήρωσης",
                         "prompt": "Πρότυπο Προτροπής",
                         "max_function_calls_per_conversation": "Μέγιστες κλήσεις συναρτήσεων ανά συνομιλία",
+                        "skills": "Skills",
                         "functions": "Συναρτήσεις",
                         "attach_username": "Επισύναψη Ονόματος Χρήστη στο Μήνυμα",
                         "context_threshold": "Όριο Περιεχομένου",
@@ -47,7 +48,11 @@
                         "temperature": "Θερμοκρασία",
                         "top_p": "Top P",
                         "reasoning_effort": "Reasoning effort",
-                        "service_tier": "Service tier"
+                        "service_tier": "Service tier",
+                        "shorten_tool_call_id": "Shorten tool call IDs"
+                    },
+                    "data_description": {
+                        "shorten_tool_call_id": "Required for Mistral AI cloud API compatibility. Enable only if your provider requires short (9-character) tool call IDs. Keep disabled for OpenAI and most other providers."
                     }
                 }
             }
@@ -73,7 +78,11 @@
                         "temperature": "Temperature",
                         "top_p": "Top P",
                         "reasoning_effort": "Reasoning effort",
-                        "service_tier": "Service tier"
+                        "service_tier": "Service tier",
+                        "shorten_tool_call_id": "Shorten tool call IDs"
+                    },
+                    "data_description": {
+                        "shorten_tool_call_id": "Required for Mistral AI cloud API compatibility. Enable only if your provider requires short (9-character) tool call IDs. Keep disabled for OpenAI and most other providers."
                     }
                 }
             }
@@ -142,6 +151,20 @@
                     "description": "The API provider. (OpenAI or Azure)"
                 }
             }
+        },
+        "download_skill": {
+            "name": "Download skill",
+            "description": "Download a skill from the GitHub repository to your skills directory. Available skills: https://github.com/jekalmin/extended_openai_conversation/tree/develop/examples/skills",
+            "fields": {
+                "skill_name": {
+                    "name": "Skill name",
+                    "description": "The name of the skill to download (e.g., crypto)"
+                }
+            }
+        },
+        "reload_skills": {
+            "name": "Reload skills",
+            "description": "Reload skills from the skills directory."
         }
     }
 }

--- a/custom_components/extended_openai_conversation/translations/en.json
+++ b/custom_components/extended_openai_conversation/translations/en.json
@@ -33,6 +33,7 @@
                         "model": "Completion Model",
                         "prompt": "Prompt Template",
                         "max_function_calls_per_conversation": "Maximum function calls per conversation",
+                        "skills": "Skills",
                         "functions": "Functions",
                         "attach_username": "Attach Username to Message",
                         "context_threshold": "Context Threshold",
@@ -150,6 +151,20 @@
                     "description": "The API provider. (OpenAI or Azure)"
                 }
             }
+        },
+        "download_skill": {
+            "name": "Download skill",
+            "description": "Download a skill from the GitHub repository to your skills directory.",
+            "fields": {
+                "skill_name": {
+                    "name": "Skill name",
+                    "description": "The name of the skill to download (e.g., crypto)"
+                }
+            }
+        },
+        "reload_skills": {
+            "name": "Reload skills",
+            "description": "Reload skills from the skills directory."
         }
     }
 }

--- a/custom_components/extended_openai_conversation/translations/fr.json
+++ b/custom_components/extended_openai_conversation/translations/fr.json
@@ -33,6 +33,7 @@
                         "model": "Modèle d'IA",
                         "prompt": "Prompt",
                         "max_function_calls_per_conversation": "Nombre maximal d'appels de fonction par conversation",
+                        "skills": "Skills",
                         "functions": "Fonctions",
                         "attach_username": "Joindre le nom d'utilisateur au message",
                         "context_threshold": "Context Threshold",
@@ -47,7 +48,11 @@
                         "temperature": "Température",
                         "top_p": "Top P",
                         "reasoning_effort": "Reasoning effort",
-                        "service_tier": "Service tier"
+                        "service_tier": "Service tier",
+                        "shorten_tool_call_id": "Shorten tool call IDs"
+                    },
+                    "data_description": {
+                        "shorten_tool_call_id": "Required for Mistral AI cloud API compatibility. Enable only if your provider requires short (9-character) tool call IDs. Keep disabled for OpenAI and most other providers."
                     }
                 }
             }
@@ -73,7 +78,11 @@
                         "temperature": "Temperature",
                         "top_p": "Top P",
                         "reasoning_effort": "Reasoning effort",
-                        "service_tier": "Service tier"
+                        "service_tier": "Service tier",
+                        "shorten_tool_call_id": "Shorten tool call IDs"
+                    },
+                    "data_description": {
+                        "shorten_tool_call_id": "Required for Mistral AI cloud API compatibility. Enable only if your provider requires short (9-character) tool call IDs. Keep disabled for OpenAI and most other providers."
                     }
                 }
             }
@@ -142,6 +151,20 @@
                     "description": "The API provider. (OpenAI or Azure)"
                 }
             }
+        },
+        "download_skill": {
+            "name": "Download skill",
+            "description": "Download a skill from the GitHub repository to your skills directory. Available skills: https://github.com/jekalmin/extended_openai_conversation/tree/develop/examples/skills",
+            "fields": {
+                "skill_name": {
+                    "name": "Skill name",
+                    "description": "The name of the skill to download (e.g., crypto)"
+                }
+            }
+        },
+        "reload_skills": {
+            "name": "Reload skills",
+            "description": "Reload skills from the skills directory."
         }
     }
 }

--- a/custom_components/extended_openai_conversation/translations/hu.json
+++ b/custom_components/extended_openai_conversation/translations/hu.json
@@ -33,6 +33,7 @@
                         "model": "Model",
                         "prompt": "Kiindulási szöveg sablon",
                         "max_function_calls_per_conversation": "Beszélgetésenkénti maximum funkcióhívások száma",
+                        "skills": "Skills",
                         "functions": "Funkciók",
                         "attach_username": "Felhasználónév hozzácsatolása az üzenethez",
                         "context_threshold": "Context Threshold",
@@ -47,7 +48,11 @@
                         "temperature": "Hőmérséklet",
                         "top_p": "Top P",
                         "reasoning_effort": "Reasoning effort",
-                        "service_tier": "Service tier"
+                        "service_tier": "Service tier",
+                        "shorten_tool_call_id": "Shorten tool call IDs"
+                    },
+                    "data_description": {
+                        "shorten_tool_call_id": "Required for Mistral AI cloud API compatibility. Enable only if your provider requires short (9-character) tool call IDs. Keep disabled for OpenAI and most other providers."
                     }
                 }
             }
@@ -73,7 +78,11 @@
                         "temperature": "Temperature",
                         "top_p": "Top P",
                         "reasoning_effort": "Reasoning effort",
-                        "service_tier": "Service tier"
+                        "service_tier": "Service tier",
+                        "shorten_tool_call_id": "Shorten tool call IDs"
+                    },
+                    "data_description": {
+                        "shorten_tool_call_id": "Required for Mistral AI cloud API compatibility. Enable only if your provider requires short (9-character) tool call IDs. Keep disabled for OpenAI and most other providers."
                     }
                 }
             }
@@ -142,6 +151,20 @@
                     "description": "The API provider. (OpenAI or Azure)"
                 }
             }
+        },
+        "download_skill": {
+            "name": "Download skill",
+            "description": "Download a skill from the GitHub repository to your skills directory. Available skills: https://github.com/jekalmin/extended_openai_conversation/tree/develop/examples/skills",
+            "fields": {
+                "skill_name": {
+                    "name": "Skill name",
+                    "description": "The name of the skill to download (e.g., crypto)"
+                }
+            }
+        },
+        "reload_skills": {
+            "name": "Reload skills",
+            "description": "Reload skills from the skills directory."
         }
     }
 }

--- a/custom_components/extended_openai_conversation/translations/it.json
+++ b/custom_components/extended_openai_conversation/translations/it.json
@@ -33,6 +33,7 @@
                         "model": "Modello di completamento",
                         "prompt": "Modello di prompt",
                         "max_function_calls_per_conversation": "Numero massimo di chiamate di funzioni per conversazione",
+                        "skills": "Skills",
                         "functions": "Funzioni",
                         "attach_username": "Allega nome utente al messaggio",
                         "context_threshold": "Soglia di contesto",
@@ -47,7 +48,11 @@
                         "temperature": "Temperatura",
                         "top_p": "Top P",
                         "reasoning_effort": "Reasoning effort",
-                        "service_tier": "Service tier"
+                        "service_tier": "Service tier",
+                        "shorten_tool_call_id": "Shorten tool call IDs"
+                    },
+                    "data_description": {
+                        "shorten_tool_call_id": "Required for Mistral AI cloud API compatibility. Enable only if your provider requires short (9-character) tool call IDs. Keep disabled for OpenAI and most other providers."
                     }
                 }
             }
@@ -73,7 +78,11 @@
                         "temperature": "Temperature",
                         "top_p": "Top P",
                         "reasoning_effort": "Reasoning effort",
-                        "service_tier": "Service tier"
+                        "service_tier": "Service tier",
+                        "shorten_tool_call_id": "Shorten tool call IDs"
+                    },
+                    "data_description": {
+                        "shorten_tool_call_id": "Required for Mistral AI cloud API compatibility. Enable only if your provider requires short (9-character) tool call IDs. Keep disabled for OpenAI and most other providers."
                     }
                 }
             }
@@ -142,6 +151,20 @@
                     "description": "The API provider. (OpenAI or Azure)"
                 }
             }
+        },
+        "download_skill": {
+            "name": "Download skill",
+            "description": "Download a skill from the GitHub repository to your skills directory. Available skills: https://github.com/jekalmin/extended_openai_conversation/tree/develop/examples/skills",
+            "fields": {
+                "skill_name": {
+                    "name": "Skill name",
+                    "description": "The name of the skill to download (e.g., crypto)"
+                }
+            }
+        },
+        "reload_skills": {
+            "name": "Reload skills",
+            "description": "Reload skills from the skills directory."
         }
     }
 }

--- a/custom_components/extended_openai_conversation/translations/ko.json
+++ b/custom_components/extended_openai_conversation/translations/ko.json
@@ -33,6 +33,7 @@
                         "model": "Completion Model",
                         "prompt": "Prompt Template",
                         "max_function_calls_per_conversation": "Maximum function calls per conversation",
+                        "skills": "Skills",
                         "functions": "Functions",
                         "attach_username": "Attach Username to Message",
                         "context_threshold": "Context Threshold",
@@ -47,7 +48,11 @@
                         "temperature": "Temperature",
                         "top_p": "Top P",
                         "reasoning_effort": "Reasoning effort",
-                        "service_tier": "Service tier"
+                        "service_tier": "Service tier",
+                        "shorten_tool_call_id": "Shorten tool call IDs"
+                    },
+                    "data_description": {
+                        "shorten_tool_call_id": "Required for Mistral AI cloud API compatibility. Enable only if your provider requires short (9-character) tool call IDs. Keep disabled for OpenAI and most other providers."
                     }
                 }
             }
@@ -73,7 +78,11 @@
                         "temperature": "Temperature",
                         "top_p": "Top P",
                         "reasoning_effort": "Reasoning effort",
-                        "service_tier": "Service tier"
+                        "service_tier": "Service tier",
+                        "shorten_tool_call_id": "Shorten tool call IDs"
+                    },
+                    "data_description": {
+                        "shorten_tool_call_id": "Required for Mistral AI cloud API compatibility. Enable only if your provider requires short (9-character) tool call IDs. Keep disabled for OpenAI and most other providers."
                     }
                 }
             }
@@ -142,6 +151,20 @@
                     "description": "The API provider. (OpenAI or Azure)"
                 }
             }
+        },
+        "download_skill": {
+            "name": "Download skill",
+            "description": "Download a skill from the GitHub repository to your skills directory. Available skills: https://github.com/jekalmin/extended_openai_conversation/tree/develop/examples/skills",
+            "fields": {
+                "skill_name": {
+                    "name": "Skill name",
+                    "description": "The name of the skill to download (e.g., crypto)"
+                }
+            }
+        },
+        "reload_skills": {
+            "name": "Reload skills",
+            "description": "Reload skills from the skills directory."
         }
     }
 }

--- a/custom_components/extended_openai_conversation/translations/nl.json
+++ b/custom_components/extended_openai_conversation/translations/nl.json
@@ -33,6 +33,7 @@
                         "model": "Completion Model",
                         "prompt": "Prompt Sjabloon",
                         "max_function_calls_per_conversation": "Maximale keren functies mogen worden aangeroepen per conversatie",
+                        "skills": "Skills",
                         "functions": "Functies",
                         "attach_username": "Gebruikersnaam aan bericht toevoegen",
                         "context_threshold": "Context Threshold",
@@ -47,7 +48,11 @@
                         "temperature": "Temperatuur",
                         "top_p": "Top P",
                         "reasoning_effort": "Reasoning effort",
-                        "service_tier": "Service tier"
+                        "service_tier": "Service tier",
+                        "shorten_tool_call_id": "Shorten tool call IDs"
+                    },
+                    "data_description": {
+                        "shorten_tool_call_id": "Required for Mistral AI cloud API compatibility. Enable only if your provider requires short (9-character) tool call IDs. Keep disabled for OpenAI and most other providers."
                     }
                 }
             }
@@ -73,7 +78,11 @@
                         "temperature": "Temperature",
                         "top_p": "Top P",
                         "reasoning_effort": "Reasoning effort",
-                        "service_tier": "Service tier"
+                        "service_tier": "Service tier",
+                        "shorten_tool_call_id": "Shorten tool call IDs"
+                    },
+                    "data_description": {
+                        "shorten_tool_call_id": "Required for Mistral AI cloud API compatibility. Enable only if your provider requires short (9-character) tool call IDs. Keep disabled for OpenAI and most other providers."
                     }
                 }
             }
@@ -142,6 +151,20 @@
                     "description": "The API provider. (OpenAI or Azure)"
                 }
             }
+        },
+        "download_skill": {
+            "name": "Download skill",
+            "description": "Download a skill from the GitHub repository to your skills directory. Available skills: https://github.com/jekalmin/extended_openai_conversation/tree/develop/examples/skills",
+            "fields": {
+                "skill_name": {
+                    "name": "Skill name",
+                    "description": "The name of the skill to download (e.g., crypto)"
+                }
+            }
+        },
+        "reload_skills": {
+            "name": "Reload skills",
+            "description": "Reload skills from the skills directory."
         }
     }
 }

--- a/custom_components/extended_openai_conversation/translations/pl.json
+++ b/custom_components/extended_openai_conversation/translations/pl.json
@@ -33,6 +33,7 @@
                         "model": "Model",
                         "prompt": "Prompt",
                         "max_function_calls_per_conversation": "Maksymalna liczba wywołań funkcji na rozmowę",
+                        "skills": "Skills",
                         "functions": "Funkcje",
                         "attach_username": "Dodaj nazwę użytkownika do wiadomości",
                         "context_threshold": "Limit kontekstu",
@@ -47,7 +48,11 @@
                         "temperature": "Temperatura",
                         "top_p": "Top P",
                         "reasoning_effort": "Reasoning effort",
-                        "service_tier": "Service tier"
+                        "service_tier": "Service tier",
+                        "shorten_tool_call_id": "Shorten tool call IDs"
+                    },
+                    "data_description": {
+                        "shorten_tool_call_id": "Required for Mistral AI cloud API compatibility. Enable only if your provider requires short (9-character) tool call IDs. Keep disabled for OpenAI and most other providers."
                     }
                 }
             }
@@ -73,7 +78,11 @@
                         "temperature": "Temperature",
                         "top_p": "Top P",
                         "reasoning_effort": "Reasoning effort",
-                        "service_tier": "Service tier"
+                        "service_tier": "Service tier",
+                        "shorten_tool_call_id": "Shorten tool call IDs"
+                    },
+                    "data_description": {
+                        "shorten_tool_call_id": "Required for Mistral AI cloud API compatibility. Enable only if your provider requires short (9-character) tool call IDs. Keep disabled for OpenAI and most other providers."
                     }
                 }
             }
@@ -142,6 +151,20 @@
                     "description": "The API provider. (OpenAI or Azure)"
                 }
             }
+        },
+        "download_skill": {
+            "name": "Download skill",
+            "description": "Download a skill from the GitHub repository to your skills directory. Available skills: https://github.com/jekalmin/extended_openai_conversation/tree/develop/examples/skills",
+            "fields": {
+                "skill_name": {
+                    "name": "Skill name",
+                    "description": "The name of the skill to download (e.g., crypto)"
+                }
+            }
+        },
+        "reload_skills": {
+            "name": "Reload skills",
+            "description": "Reload skills from the skills directory."
         }
     }
 }

--- a/custom_components/extended_openai_conversation/translations/pt-BR.json
+++ b/custom_components/extended_openai_conversation/translations/pt-BR.json
@@ -33,6 +33,7 @@
                         "model": "Modelo da Conclusão",
                         "prompt": "Template do Prompt",
                         "max_function_calls_per_conversation": "Quantidade máxima de chamadas por conversação",
+                        "skills": "Skills",
                         "functions": "Funções",
                         "attach_username": "Anexar nome do usuário na mensagem",
                         "context_threshold": "Limite do contexto",
@@ -47,7 +48,11 @@
                         "temperature": "Temperatura",
                         "top_p": "Top P",
                         "reasoning_effort": "Reasoning effort",
-                        "service_tier": "Service tier"
+                        "service_tier": "Service tier",
+                        "shorten_tool_call_id": "Shorten tool call IDs"
+                    },
+                    "data_description": {
+                        "shorten_tool_call_id": "Required for Mistral AI cloud API compatibility. Enable only if your provider requires short (9-character) tool call IDs. Keep disabled for OpenAI and most other providers."
                     }
                 }
             }
@@ -73,7 +78,11 @@
                         "temperature": "Temperature",
                         "top_p": "Top P",
                         "reasoning_effort": "Reasoning effort",
-                        "service_tier": "Service tier"
+                        "service_tier": "Service tier",
+                        "shorten_tool_call_id": "Shorten tool call IDs"
+                    },
+                    "data_description": {
+                        "shorten_tool_call_id": "Required for Mistral AI cloud API compatibility. Enable only if your provider requires short (9-character) tool call IDs. Keep disabled for OpenAI and most other providers."
                     }
                 }
             }
@@ -142,6 +151,20 @@
                     "description": "The API provider. (OpenAI or Azure)"
                 }
             }
+        },
+        "download_skill": {
+            "name": "Download skill",
+            "description": "Download a skill from the GitHub repository to your skills directory. Available skills: https://github.com/jekalmin/extended_openai_conversation/tree/develop/examples/skills",
+            "fields": {
+                "skill_name": {
+                    "name": "Skill name",
+                    "description": "The name of the skill to download (e.g., crypto)"
+                }
+            }
+        },
+        "reload_skills": {
+            "name": "Reload skills",
+            "description": "Reload skills from the skills directory."
         }
     }
 }

--- a/custom_components/extended_openai_conversation/translations/pt.json
+++ b/custom_components/extended_openai_conversation/translations/pt.json
@@ -33,6 +33,7 @@
                         "model": "Modelo da Conclusão",
                         "prompt": "Template do Prompt",
                         "max_function_calls_per_conversation": "Quantidade máxima de chamadas por conversação",
+                        "skills": "Skills",
                         "functions": "Funções",
                         "attach_username": "Anexar nome do usuário na mensagem",
                         "context_threshold": "Limite do contexto",
@@ -47,7 +48,11 @@
                         "temperature": "Temperatura",
                         "top_p": "Top P",
                         "reasoning_effort": "Reasoning effort",
-                        "service_tier": "Service tier"
+                        "service_tier": "Service tier",
+                        "shorten_tool_call_id": "Shorten tool call IDs"
+                    },
+                    "data_description": {
+                        "shorten_tool_call_id": "Required for Mistral AI cloud API compatibility. Enable only if your provider requires short (9-character) tool call IDs. Keep disabled for OpenAI and most other providers."
                     }
                 }
             }
@@ -73,7 +78,11 @@
                         "temperature": "Temperature",
                         "top_p": "Top P",
                         "reasoning_effort": "Reasoning effort",
-                        "service_tier": "Service tier"
+                        "service_tier": "Service tier",
+                        "shorten_tool_call_id": "Shorten tool call IDs"
+                    },
+                    "data_description": {
+                        "shorten_tool_call_id": "Required for Mistral AI cloud API compatibility. Enable only if your provider requires short (9-character) tool call IDs. Keep disabled for OpenAI and most other providers."
                     }
                 }
             }
@@ -142,6 +151,20 @@
                     "description": "The API provider. (OpenAI or Azure)"
                 }
             }
+        },
+        "download_skill": {
+            "name": "Download skill",
+            "description": "Download a skill from the GitHub repository to your skills directory. Available skills: https://github.com/jekalmin/extended_openai_conversation/tree/develop/examples/skills",
+            "fields": {
+                "skill_name": {
+                    "name": "Skill name",
+                    "description": "The name of the skill to download (e.g., crypto)"
+                }
+            }
+        },
+        "reload_skills": {
+            "name": "Reload skills",
+            "description": "Reload skills from the skills directory."
         }
     }
 }

--- a/examples/prompt/default/README.md
+++ b/examples/prompt/default/README.md
@@ -16,96 +16,57 @@
 ## Prompt
 
 ````yaml
-You are a voice assistant for Home Assistant.
+You are a helpful AI voice assistant of Home Assistant that controls a real home.
+Your goal is to proactively improve the user's comfort.
 
-Answer in plain text only.
-Respond naturally as a voice assistant.
-Prefer a single sentence; use up to 2-3 sentences only when truly necessary.
-Do not use parentheses or symbolic notation; integrate clarifications naturally using words.
+## Environment State
+- Current Time: {{now()}}
+- Current Area: {{area_id(current_device_id)}}
 
-For smart home interactions, follow this decision flow strictly:
+## Workspace
+Your workspace is at: {{extended_openai.working_directory()}}
 
-0. Action classification
-   Distinguish between two types of actions:
-   A. Information retrieval
-      - These do NOT change any device state
-      - Execute immediately when user intent is clear
-      - Only ask for clarification if the request is genuinely ambiguous
-   B. State-changing actions
-      - These DO change device state
-      - Execute immediately when user explicitly specifies the device and the exact action with clear values
-      - Require confirmation only when the request is ambiguous or lacks specific values
-      - If you have already proposed an action and the user responds with a specification or refinement, treat this as explicit confirmation and execute immediately
+## Guidelines
+- Answer in plain text only.
+- Do not use parentheses or symbolic notation
+- Ask for clarification when the request is ambiguous
+- Use tools to help accomplish tasks
 
-1. Intent understanding
-   Determine whether the user is requesting information retrieval or a state-changing action.
-   Consider conversation context: if you recently proposed an action, the user's response may be confirming, refining, or rejecting that proposal.
+## Personality
+- Helpful and friendly
+- Concise and to the point
+- Curious and eager to learn
 
-2. Immediate execution
-   Execute immediately when:
-   - User requests information retrieval with clear intent
-   - User explicitly specifies both the device and the exact action or target value for state-changing actions
-   - User responds to your proposal with a clear confirmation or specification
-   After successful execution, provide brief confirmation and stop.
+## Behavior Policy
+- If the user explicitly names a device and action, execute it directly.
+- Otherwise, infer the user's goal and select the most likely target entity, preferring primary environmental controls. Use get_attributes to check adjustable state values alone is not sufficient.
+- If the selected entity is already at its limit, evaluate the next most likely entity. Repeat until a viable adjustment is found or all candidates are exhausted.
+- Ask user a minimum adjustment proposal about selected entity. If no entity can further improve the situation, inform the user that conditions are already optimal.
 
-3. Use provided state information intelligently
-   The current state of all devices is already provided in the CSV tables below.
-   For information available in the provided CSV:
-   - Always use this information directly
-   - Do NOT use tools to retrieve information that is already provided
-   For information NOT available in the provided CSV:
-   - If your response requires additional data beyond what is provided in the CSV, use available tools to retrieve that information
-   - Only retrieve additional information when necessary
-
-4. Context-aware proposal logic
-   When the user's intent requires clarification or lacks specific values:
-   a) Examine the provided CSV to identify devices relevant to the user's intent and their current states
-   b) Determine if the intent can be satisfied by changing device states shown in the CSV:
-      - If the required action is a simple state change but the target is ambiguous, propose a specific option
-   c) If the relevant devices are already in an appropriate state for the intent, or if proposing a meaningful adjustment requires knowing current parameter values:
-      - Retrieve the relevant adjustable parameters using available tools
-      - Use the current parameter values to propose a contextually appropriate adjustment
-      - The proposal should be relative to the current value, not an arbitrary target
-      - If parameters are already at their limits for the user's goal, inform the user
-   d) Propose one minimal and reasonable adjustment based on complete information
-   e) Always end with a confirmation question; never trigger execution
-
-5. State reference in confirmation questions
-   When asking for confirmation:
-   - For numeric states: Always mention the current value to provide context
-   - For binary states: Omit the current state as the proposed action implies the current state
-   - Keep confirmation questions concise while providing necessary context
-   - Propose a single concrete action and await explicit user approval
-
-When referring to the smart home state,
-use only the information provided below or retrieved through allowed tools.
-
-For general knowledge questions not related to the home,
-answer truthfully using internal knowledge only.
-
-Current Time: {{now()}}
-Current Area: {{area_id(current_device_id)}}
-
-An overview of the areas and the available devices:
-{%- set area_entities = namespace(mapping={}) %}
-{%- for entity in extended_openai.exposed_entities() %}
-    {%- set current_area_id = area_id(entity.entity_id) or "etc" %}
-    {%- set entities = (area_entities.mapping.get(current_area_id) or []) + [entity] %}
-    {%- set area_entities.mapping = dict(area_entities.mapping, **{current_area_id: entities}) -%}
-{%- endfor %}
-
-{%- for current_area_id, entities in area_entities.mapping.items() %}
-
-  {%- if current_area_id == "etc" %}
-  Etc:
-  {%- else %}
-  {{area_name(current_area_id)}}:
-  {%- endif %}
+## Devices
+Available Devices:
 ```csv
-    entity_id,name,state,aliases
-    {%- for entity in entities %}
-    {{ entity.entity_id }},{{ entity.name }},{{ entity.state }},{{ entity.aliases | join('/') }}
-    {%- endfor %}
+entity_id,name,state,area_id,aliases
+{% for entity in extended_openai.exposed_entities() -%}
+{{ entity.entity_id }},{{ entity.name }},{{ entity.state }},{{area_id(entity.entity_id)}},{{entity.aliases | join('/')}}
+{% endfor -%}
 ```
-{%- endfor %}
+
+{%- if skills %}
+## Skills
+The following skills extend your capabilities. To use a skill, call load_skill with the skill name to read its instructions.
+When a skill file references a relative path, resolve it against the skill's location directory (e.g., skill at `/a/b/SKILL.md` references `scripts/run.py` → use `/a/b/scripts/run.py`) and always use the resulting absolute path in bash commands, as relative paths will fail.
+
+<available_skills>
+{%- for skill in skills %}
+  <skill>
+    <name>{{ skill.name }}</name>
+    <description>{{ skill.description }}</description>
+    <location>{{skill.path}}</location>
+  </skill>
+ {%- endfor %}
+</available_skills>
+{% endif %}
+
+{{user_input.extra_system_prompt | default('', true)}}
 ````

--- a/examples/skills/README.md
+++ b/examples/skills/README.md
@@ -1,0 +1,233 @@
+# Skills
+
+This directory contains example skills for Extended OpenAI Conversation. Skills provide reusable AI capabilities that can be enabled per conversation.
+
+## Installing Skills
+
+### Method 1: Download from Repository (Recommended)
+
+Use the `download_skill` service to automatically download and install skills:
+
+```yaml
+service: extended_openai_conversation.download_skill
+data:
+  skill_name: crypto
+```
+
+This service:
+- Downloads the skill from the GitHub repository
+- Saves it to `<config>/extended_openai_conversation/skills/`
+- Automatically reloads all skills
+- Returns the list of downloaded files
+
+### Method 2: Manual Installation
+
+1. **Copy the skill directory** to your Home Assistant config:
+   ```bash
+   cp -r crypto /config/extended_openai_conversation/skills/
+   ```
+
+2. **Make scripts executable** (if applicable):
+   ```bash
+   chmod +x /config/extended_openai_conversation/skills/crypto/scripts/crypto.py
+   ```
+
+3. **Reload skills** via service call:
+   ```yaml
+   service: extended_openai_conversation.reload_skills
+   ```
+
+   This service returns the number of loaded skills.
+
+### Enabling Skills
+
+After installation, enable skills for your conversation:
+
+1. Go to Settings > Voice Assistants
+2. Edit your Extended OpenAI Conversation assistant
+3. Click "Options"
+4. Select the skills you want to enable from the list
+
+**Note:** Skills are enabled per conversation entity. You can have different skills enabled for different assistants.
+
+<img width="400" height="477" alt="스크린샷 2026-02-12 오후 5 11 15" src="https://github.com/user-attachments/assets/0264a5f1-c05c-4aae-90c6-78aea4b086f0" />
+
+### System Prompt
+
+When skills are enabled for a conversation, the following system prompt adds available skills to inform the AI:
+
+```jinja2
+{%- if skills %}
+## Skills
+The following skills extend your capabilities. To use a skill, call load_skill with the skill name to read its instructions.
+When a skill file references a relative path, resolve it against the skill's location directory (e.g., skill at `/a/b/SKILL.md` references `scripts/run.py` → use `/a/b/scripts/run.py`) and always use the resulting absolute path in bash commands, as relative paths will fail.
+
+<available_skills>
+{%- for skill in skills %}
+  <skill>
+    <name>{{ skill.name }}</name>
+    <description>{{ skill.description }}</description>
+    <location>{{skill.path}}</location>
+  </skill>
+ {%- endfor %}
+</available_skills>
+{% endif %}
+```
+
+This prompt:
+- Lists all enabled skills with their names, descriptions, and file locations
+- Instructs the AI to call `load_skill` to read detailed skill instructions
+- Explains path resolution: relative paths in skill files must be converted to absolute paths using the skill's location directory
+- Ensures bash commands use absolute paths to avoid execution errors
+
+**Important for Skill Authors:** When writing skill instructions, you can reference files using relative paths (e.g., `scripts/crypto.py`), but remind the AI in your instructions that these must be resolved to absolute paths when executing commands.
+
+### Functions
+
+#### Load Skill Files
+
+To read files from your skill's directory, configure the `load_skill` function:
+
+```yaml
+- spec:
+    name: load_skill
+    description: Load a file from a skill's directory.
+    parameters:
+      type: object
+      properties:
+        name:
+          type: string
+          description: Skill name
+        file:
+          type: string
+          description: Relative file path within the skill directory
+      required:
+      - name
+      - file
+  function:
+    type: read_file
+    path: '{{extended_openai.skill_dir(name)}}/{{file}}'
+```
+
+This allows the AI to load data files, or other resources bundled with your skill.
+
+#### Execute Bash Commands
+
+To enable bash command execution in the workspace, configure the `bash` function:
+
+```yaml
+- spec:
+    name: bash
+    description: Execute a bash command in workspace.
+    parameters:
+      type: object
+      properties:
+        command:
+          type: string
+          description: Bash command to execute
+      required:
+      - command
+  function:
+    type: bash
+    command: '{{command}}'
+```
+
+This allows skills to run shell commands, execute scripts, call external programs, and process data using command-line tools.
+
+**Security Note:** Bash execution is restricted to the workspace directory (by default `<config directory>/extended_openai_conversation/`) and has deny patterns for destructive commands.
+
+## Managing Skills
+
+### Reload Skills
+
+After manually creating or modifying skills, reload them to apply changes:
+
+```yaml
+service: extended_openai_conversation.reload_skills
+```
+
+This service:
+- Scans the skills directory
+- Reloads all `SKILL.md` files
+- Returns the number of loaded skills
+
+**When to reload:**
+- After manually creating a new skill
+- After editing existing `SKILL.md` files
+- After modifying skill metadata (name or description)
+
+**Note:** You don't need to reload after using `download_skill` service, as it automatically reloads skills.
+
+## Creating Your Own Skills
+
+### Skill Directory Structure
+
+Each skill is a directory under `<config>/extended_openai_conversation/skills/` with a `SKILL.md` file:
+
+```
+<config>/extended_openai_conversation/skills/
+└── your_skill_name/
+    ├── SKILL.md           # Required: skill definition
+    ├── scripts/           # Optional: scripts, tools, etc.
+    │   └── helper.py
+    └── references/        # Optional: reference data, documentation, etc.
+        └── example.md
+```
+
+### SKILL.md Format
+
+The `SKILL.md` file consists of two parts:
+
+#### 1. YAML Frontmatter (Required)
+
+```yaml
+---
+name: your_skill_name      # Used as identifier (max 64 chars)
+description: Brief description of what this skill does and when to use it (max 1024 chars)
+---
+```
+
+**Fields:**
+- `name`: Directory name used as the skill identifier (required, max 64 characters)
+- `description`: Brief description shown in the skills list and helps the AI decide when to use this skill (required, max 1024 characters)
+
+#### 2. Markdown Body (Instructions for AI)
+
+The body contains detailed instructions and examples for the AI agent:
+
+```markdown
+# Skill Title
+
+## Contributing
+
+To contribute new skills:
+
+1. Create your skill following the structure above
+2. Test thoroughly with various user queries
+3. Submit a pull request with your skill in `examples/skills/`
+4. Include a clear description and usage examples
+```
+
+### Best Practices
+
+1. **Clear Description**: Write a concise description (under 1024 chars) that clearly explains when the skill should be used. This helps the AI decide whether to activate this skill.
+
+2. **Detailed Instructions**: Provide step-by-step guidance that the AI can follow autonomously. Be specific about:
+   - Exact commands to run
+   - File paths (use relative paths from skill directory)
+   - Expected inputs and outputs
+   - Error handling
+
+3. **Concrete Examples**: Include 2-3 examples showing:
+   - Typical user requests
+   - Exact actions the AI should take
+   - Expected response format
+
+4. **Command Syntax**: If using bash or scripts, specify exact syntax:
+   - ✅ Good: `python3 scripts/crypto.py btc`
+   - ❌ Bad: "Run the crypto script"
+
+5. **Response Format**: Show how to format responses to users, including:
+   - What information to include
+   - How to attribute sources
+   - Handling of errors or edge cases

--- a/examples/skills/crypto/SKILL.md
+++ b/examples/skills/crypto/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: crypto
+description: Get real-time cryptocurrency prices. Use when users ask about Bitcoin, Ethereum, or other crypto prices and market data.
+---
+
+# Cryptocurrency Price Checker
+
+## Instructions
+
+1. **Identify the cryptocurrency** the user is asking about (Bitcoin, Ethereum, Solana, etc.)
+
+2. **Execute the appropriate script**
+   - `python3 scripts/crypto.py btc` - Get Bitcoin price
+   - `python3 scripts/crypto.py eth` - Get Ethereum price
+   - `python3 scripts/crypto.py sol` - Get Solana price
+   - `python3 scripts/crypto.py doge` - Get Dogecoin price
+   - `python3 scripts/crypto.py <symbol>` - Get any crypto price by symbol
+
+3. **Format the response** with:
+   - USD price (and local currency if applicable)
+   - 24-hour price change percentage
+   - Source attribution to CoinGecko
+   - Note that crypto prices are volatile and change rapidly
+
+## Examples
+
+**User:** "What's the current Bitcoin price?"
+**Action:** Execute `python3 scripts/crypto.py btc`
+**Response:** "Bitcoin is currently trading at $67,234. It has changed +2.3% in the last 24 hours. (Source: CoinGecko)"
+
+**User:** "How much is Ethereum worth?"
+**Action:** Execute `python3 scripts/crypto.py eth`
+**Response:** "Ethereum is currently priced at $3,456, down -1.2% over the past 24 hours. (Source: CoinGecko)"
+
+**User:** "Check Solana and Dogecoin prices"
+**Action:** Execute `python3 scripts/crypto.py sol` and `python scripts/crypto.py doge`
+**Response:** "Current prices - Solana: $145 (+5.7% 24h), Dogecoin: $0.12 (+0.8% 24h). (Source: CoinGecko)"

--- a/examples/skills/crypto/scripts/crypto.py
+++ b/examples/skills/crypto/scripts/crypto.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Fetch cryptocurrency prices from CoinGecko API.
+
+Usage: python crypto.py <symbol>
+Example: python crypto.py btc
+"""
+
+from datetime import UTC, datetime
+import json
+import sys
+import urllib.error
+import urllib.request
+
+
+def get_coin_id(symbol: str) -> str:
+    """Map common symbols to CoinGecko IDs."""
+    symbol_map = {
+        "btc": "bitcoin",
+        "bitcoin": "bitcoin",
+        "eth": "ethereum",
+        "ethereum": "ethereum",
+        "sol": "solana",
+        "solana": "solana",
+        "xrp": "ripple",
+        "ripple": "ripple",
+        "ada": "cardano",
+        "cardano": "cardano",
+        "doge": "dogecoin",
+        "dogecoin": "dogecoin",
+    }
+    return symbol_map.get(symbol.lower(), symbol.lower())
+
+
+def fetch_crypto_price(coin_id: str) -> dict:
+    """Fetch price from CoinGecko API."""
+    url = f"https://api.coingecko.com/api/v3/simple/price?ids={coin_id}&vs_currencies=usd,krw&include_24hr_change=true"
+
+    try:
+        with urllib.request.urlopen(url) as response:
+            data: dict = json.loads(response.read().decode())
+
+        # Check if response contains error or empty data
+        if not data or coin_id not in data:
+            return {"error": f"Failed to fetch price for {coin_id}", "response": data}
+
+        return data
+
+    except urllib.error.URLError as e:
+        return {
+            "error": f"Network error while fetching price for {coin_id}",
+            "details": str(e),
+        }
+    except json.JSONDecodeError as e:
+        return {"error": f"Invalid JSON response for {coin_id}", "details": str(e)}
+
+
+def main() -> None:
+    """Main entry point."""
+    # Get symbol from command line, default to 'btc'
+    symbol = sys.argv[1] if len(sys.argv) > 1 else "btc"
+
+    # Map symbol to CoinGecko ID
+    coin_id = get_coin_id(symbol)
+
+    # Fetch price data
+    response = fetch_crypto_price(coin_id)
+
+    # Check for errors in response
+    if "error" in response:
+        print(json.dumps(response))
+        sys.exit(1)
+
+    # Add timestamp and format final response
+    timestamp = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+    result = {"coin": coin_id, "timestamp": timestamp, "data": response}
+
+    print(json.dumps(result))
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dev = [
 
 [tool.ruff]
 target-version = "py314"
+extend-include = ["custom_components/extended_openai_conversation/**/*.py"]
 
 [tool.ruff.lint]
 select = [
@@ -59,4 +60,5 @@ python_version = "3.14"
 ignore_missing_imports = true
 warn_return_any = true
 warn_unused_configs = true
+files = ["custom_components/extended_openai_conversation/**/*.py"]
 exclude = ["tests/"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,9 @@ from homeassistant.helpers.template import TemplateEnvironment  # noqa: E402
 def hass(tmp_path: Path) -> MagicMock:
     """Mock Home Assistant instance."""
     hass = MagicMock()
+    # Create extended_openai_conversation directory in tmp_path
+    workdir = tmp_path / "extended_openai_conversation"
+    workdir.mkdir(parents=True, exist_ok=True)
     hass.config.config_dir = str(tmp_path)
     hass.states = MagicMock()
     hass.states.get = MagicMock(return_value=MagicMock(state="on"))

--- a/tests/fixtures/functions/bash_example.yaml
+++ b/tests/fixtures/functions/bash_example.yaml
@@ -1,0 +1,136 @@
+- spec:
+    name: list_directory
+    description: List files in current directory
+    parameters:
+      type: object
+      properties: {}
+      required: []
+  function:
+    type: bash
+    command: "ls -la"
+
+- spec:
+    name: list_root_directory_restricted
+    description: List root directory (should be blocked by workspace restriction)
+    parameters:
+      type: object
+      properties: {}
+      required: []
+  function:
+    type: bash
+    command: "ls -la /root"
+
+- spec:
+    name: list_root_directory_unrestricted
+    description: List root directory with workspace restriction disabled
+    parameters:
+      type: object
+      properties: {}
+      required: []
+  function:
+    type: bash
+    command: "ls -la /root"
+    restrict_to_workspace: false
+
+- spec:
+    name: print_working_directory
+    description: Print current working directory
+    parameters:
+      type: object
+      properties: {}
+      required: []
+  function:
+    type: bash
+    command: "pwd"
+
+- spec:
+    name: pwd_blocked_by_allowlist
+    description: PWD command that should be blocked by allow patterns
+    parameters:
+      type: object
+      properties: {}
+      required: []
+  function:
+    type: bash
+    command: "pwd"
+    allow_patterns:
+    - "^ls "
+    - "^echo "
+
+- spec:
+    name: rm_rf
+    description: rm rf
+    parameters:
+      type: object
+      properties: {}
+      required: []
+  function:
+    type: bash
+    command: "rm -rf ."
+
+- spec:
+    name: chmod_recursive
+    description: Change permissions recursively (dangerous)
+    parameters:
+      type: object
+      properties: {}
+      required: []
+  function:
+    type: bash
+    command: "chmod -R 777 ."
+
+- spec:
+    name: disk_wipe
+    description: Wipe disk with dd (extremely dangerous)
+    parameters:
+      type: object
+      properties: {}
+      required: []
+  function:
+    type: bash
+    command: "dd if=/dev/zero of=/dev/sda"
+
+- spec:
+    name: path_traversal_attack
+    description: Path traversal attack using relative paths
+    parameters:
+      type: object
+      properties: {}
+      required: []
+  function:
+    type: bash
+    command: "cat ../../../etc/passwd"
+
+# 위험한 명령어 예시
+
+- spec:
+    name: custom_directory_command
+    description: Read file from custom directory using cwd parameter
+    parameters:
+      type: object
+      properties:
+        directory:
+          type: string
+          description: Custom directory path
+        filename:
+          type: string
+          description: Filename to read
+      required:
+      - directory
+      - filename
+  function:
+    type: bash
+    command: "cat {{ filename }}"
+    cwd: "{{ directory }}"
+    restrict_to_workspace: false
+
+- spec:
+    name: generate_long_output
+    description: Generate output longer than truncation limit to test output truncation
+    parameters:
+      type: object
+      properties: {}
+      required: []
+  function:
+    type: bash
+    command: "python3 -c \"print('A' * 20000)\""

--- a/tests/fixtures/functions/edit_file_example.yaml
+++ b/tests/fixtures/functions/edit_file_example.yaml
@@ -1,0 +1,76 @@
+- spec:
+    name: edit_test_file
+    description: Edit a test file
+    parameters:
+      type: object
+      properties:
+        filename:
+          type: string
+          description: Name of file to edit
+        old_text:
+          type: string
+          description: Text to replace
+        new_text:
+          type: string
+          description: New text
+      required:
+      - filename
+      - old_text
+      - new_text
+  function:
+    type: edit_file
+    path: "{{ filename }}"
+    old_text: "{{ old_text }}"
+    new_text: "{{ new_text }}"
+
+- spec:
+    name: edit_with_custom_allow_dir
+    description: Edit file in custom allowed directory
+    parameters:
+      type: object
+      properties:
+        filepath:
+          type: string
+          description: Path to file
+        old_text:
+          type: string
+          description: Text to replace
+        new_text:
+          type: string
+          description: New text
+      required:
+      - filepath
+      - old_text
+      - new_text
+  function:
+    type: edit_file
+    path: "{{ filepath }}"
+    old_text: "{{ old_text }}"
+    new_text: "{{ new_text }}"
+    allow_dir:
+    - "/tmp"
+
+- spec:
+    name: edit_unicode_file
+    description: Edit file with unicode content
+    parameters:
+      type: object
+      properties:
+        filename:
+          type: string
+          description: Name of file to edit
+        old_text:
+          type: string
+          description: Text to replace
+        new_text:
+          type: string
+          description: New text
+      required:
+      - filename
+      - old_text
+      - new_text
+  function:
+    type: edit_file
+    path: "{{ filename }}"
+    old_text: "{{ old_text }}"
+    new_text: "{{ new_text }}"

--- a/tests/fixtures/functions/read_file_example.yaml
+++ b/tests/fixtures/functions/read_file_example.yaml
@@ -1,0 +1,72 @@
+- spec:
+    name: read_relative_path
+    description: relative path from working directory
+    parameters:
+      type: object
+      properties:
+        filename:
+          type: string
+          description: Name of file to read
+          default: test.txt
+      required: []
+  function:
+    type: read_file
+    path: "{{ filename }}"
+
+- spec:
+    name: read_absolute_path_of_working_directory
+    description: Read file with absolute path
+    parameters:
+      type: object
+      properties:
+        filepath:
+          type: string
+          description: Absolute path to file
+      required:
+      - filepath
+  function:
+    type: read_file
+    path: "{{ filepath }}"
+
+- spec:
+    name: read_absolute_path_outside_working_directory
+    description: Read file with absolute path
+    parameters:
+      type: object
+      properties:
+        filepath:
+          type: string
+          description: Absolute path to file
+      required:
+      - filepath
+  function:
+    type: read_file
+    path: "{{ filepath }}"
+
+- spec:
+    name: read_with_custom_allow_dir
+    description: Read file from custom allowed directory
+    parameters:
+      type: object
+      properties:
+        filepath:
+          type: string
+          description: Path to file
+      required:
+      - filepath
+  function:
+    type: read_file
+    path: "{{ filepath }}"
+    allow_dir:
+    - "/tmp"
+
+- spec:
+    name: read_unicode_file
+    description: Read file with unicode content
+    parameters:
+      type: object
+      properties: {}
+      required: []
+  function:
+    type: read_file
+    path: "unicode.txt"

--- a/tests/fixtures/functions/write_file_example.yaml
+++ b/tests/fixtures/functions/write_file_example.yaml
@@ -1,0 +1,121 @@
+- spec:
+    name: write_relative_path
+    description: relative path from working directory
+    parameters:
+      type: object
+      properties:
+        filename:
+          type: string
+          description: Name of file to write
+        content:
+          type: string
+          description: Content to write to file
+      required:
+      - filename
+      - content
+  function:
+    type: write_file
+    path: "{{ filename }}"
+    content: "{{ content }}"
+
+- spec:
+    name: write_absolute_path
+    description: Write file with absolute path
+    parameters:
+      type: object
+      properties:
+        filepath:
+          type: string
+          description: Absolute path to file
+        content:
+          type: string
+          description: Content to write
+      required:
+      - filepath
+      - content
+  function:
+    type: write_file
+    path: "{{ filepath }}"
+    content: "{{ content }}"
+
+- spec:
+    name: write_with_custom_allow_dir
+    description: Write file to custom allowed directory
+    parameters:
+      type: object
+      properties:
+        filepath:
+          type: string
+          description: Path to file
+        content:
+          type: string
+          description: Content to write
+      required:
+      - filepath
+      - content
+  function:
+    type: write_file
+    path: "{{ filepath }}"
+    content: "{{ content }}"
+    allow_dir:
+    - "/tmp"
+
+- spec:
+    name: write_unicode_file
+    description: Write file with unicode content
+    parameters:
+      type: object
+      properties:
+        filename:
+          type: string
+          description: Name of file to write
+        content:
+          type: string
+          description: Unicode content to write
+      required:
+      - filename
+      - content
+  function:
+    type: write_file
+    path: "{{ filename }}"
+    content: "{{ content }}"
+
+- spec:
+    name: write_empty_file
+    description: Write empty file
+    parameters:
+      type: object
+      properties:
+        filename:
+          type: string
+          description: Name of file to write
+        content:
+          type: string
+          description: Content to write
+          default: ""
+      required:
+      - filename
+  function:
+    type: write_file
+    path: "{{ filename }}"
+    content: "{{ content }}"
+
+- spec:
+    name: write_multiline_file
+    description: Write file with multiline content
+    parameters:
+      type: object
+      properties:
+        filename:
+          type: string
+          description: Name of file to write
+        content:
+          type: string
+          description: Multiline content to write
+      required:
+      - filename
+      - content
+  function:
+    type: write_file
+    path: "{{ filename }}"
+    content: "{{ content }}"

--- a/tests/function_executors/test_bash.py
+++ b/tests/function_executors/test_bash.py
@@ -1,0 +1,246 @@
+"""Tests for BashFunctionExecutor using yaml definitions."""
+
+import pytest
+
+from custom_components.extended_openai_conversation.helpers import (
+    BashFunctionExecutor,
+    get_function_executor,
+)
+from tests.helpers import get_function_from_yaml
+
+
+class TestBashFunctionExecutorYaml:
+    """Test BashFunctionExecutor using yaml definitions."""
+
+    @pytest.fixture
+    def executor(self):
+        """Create BashFunctionExecutor instance."""
+        return BashFunctionExecutor()
+
+    async def test_list_directory_from_yaml(
+        self, hass, executor, exposed_entities, llm_context
+    ):
+        """Test list_directory command from yaml definition."""
+        func_def = get_function_from_yaml("bash_example.yaml", 0)
+        function_executor = get_function_executor(func_def["function"]["type"])
+        processed_function = function_executor.to_arguments(func_def["function"])
+
+        arguments = {}
+
+        result = await executor.execute(
+            hass, processed_function, arguments, llm_context, exposed_entities
+        )
+
+        assert result["exit_code"] == 0
+        assert result["stdout"]  # Should have some directory listing output
+
+    async def test_custom_directory_command_from_yaml(
+        self, hass, executor, exposed_entities, llm_context, tmp_path
+    ):
+        """Test custom_directory_command with cwd parameter from yaml."""
+        # Create test file
+        test_dir = tmp_path / "bash_test"
+        test_dir.mkdir()
+        test_file = test_dir / "test.txt"
+        test_file.write_text("test content")
+
+        func_def = get_function_from_yaml("bash_example.yaml", 9)
+        function_executor = get_function_executor(func_def["function"]["type"])
+        processed_function = function_executor.to_arguments(func_def["function"])
+
+        arguments = {"directory": str(test_dir), "filename": "test.txt"}
+
+        result = await executor.execute(
+            hass, processed_function, arguments, llm_context, exposed_entities
+        )
+
+        assert result["exit_code"] == 0
+        assert "test content" in result["stdout"]
+
+    async def test_print_working_directory_from_yaml(
+        self, hass, executor, exposed_entities, llm_context
+    ):
+        """Test print_working_directory command from yaml."""
+        func_def = get_function_from_yaml("bash_example.yaml", 3)
+        function_executor = get_function_executor(func_def["function"]["type"])
+        processed_function = function_executor.to_arguments(func_def["function"])
+
+        arguments = {}
+
+        result = await executor.execute(
+            hass, processed_function, arguments, llm_context, exposed_entities
+        )
+
+        assert result["exit_code"] == 0
+        assert result["stdout"]  # Should have current directory path
+
+    async def test_deny_patterns(
+        self, hass, executor, exposed_entities, llm_context
+    ):
+        """Test that deny patterns block commands."""
+        dangerous_commands = [
+            "rm -rf /",
+            "dd if=/dev/zero of=/dev/sda",
+            "mkfs.ext4 /dev/sda1",
+            "> /etc/passwd",
+        ]
+
+        for cmd in dangerous_commands:
+            from homeassistant.helpers.template import Template
+            function = {
+                "type": "bash",
+                "command": Template(cmd, hass),
+            }
+            arguments = {}
+
+            result = await executor.execute(
+                hass, function, arguments, llm_context, exposed_entities
+            )
+
+            assert "error" in result
+            assert "blocked" in result["error"].lower()
+
+    async def test_path_traversal_protection(
+        self, hass, executor, exposed_entities, llm_context
+    ):
+        """Test that path traversal is blocked."""
+        from homeassistant.helpers.template import Template
+        function = {
+            "type": "bash",
+            "command": Template("cat ../../../etc/passwd", hass),
+        }
+        arguments = {}
+
+        result = await executor.execute(
+            hass, function, arguments, llm_context, exposed_entities
+        )
+
+        assert "error" in result
+        assert "traversal" in result["error"].lower()
+
+    async def test_list_root_directory_with_description_from_yaml(
+        self, hass, executor, exposed_entities, llm_context
+    ):
+        """Test list_root_directory with restrict_to_workspace in description from yaml."""
+        func_def = get_function_from_yaml("bash_example.yaml", 1)
+        function_executor = get_function_executor(func_def["function"]["type"])
+        processed_function = function_executor.to_arguments(func_def["function"])
+
+        arguments = {}
+
+        result = await executor.execute(
+            hass, processed_function, arguments, llm_context, exposed_entities
+        )
+
+        # Should be blocked by workspace restriction (no explicit restrict_to_workspace: false)
+        assert "error" in result
+
+    async def test_restrict_to_workspace_false(
+        self, hass, executor, exposed_entities, llm_context
+    ):
+        """Test that restrict_to_workspace=false allows commands outside workspace."""
+        func_def = get_function_from_yaml("bash_example.yaml", 2)
+        function_executor = get_function_executor(func_def["function"]["type"])
+        processed_function = function_executor.to_arguments(func_def["function"])
+
+        arguments = {}
+
+        result = await executor.execute(
+            hass, processed_function, arguments, llm_context, exposed_entities
+        )
+
+        # Should not have error about workspace restriction
+        # Note: Command tries to access /root which may fail due to permissions,
+        # but should not fail due to workspace restriction
+        assert "error" not in result or "workspace" not in result.get("error", "").lower()
+
+    async def test_allow_patterns_blocks_unlisted_from_yaml(
+        self, hass, executor, exposed_entities, llm_context
+    ):
+        """Test that allow patterns block unlisted commands from yaml."""
+        func_def = get_function_from_yaml("bash_example.yaml", 4)
+        function_executor = get_function_executor(func_def["function"]["type"])
+        processed_function = function_executor.to_arguments(func_def["function"])
+
+        arguments = {}
+
+        result = await executor.execute(
+            hass, processed_function, arguments, llm_context, exposed_entities
+        )
+
+        assert "error" in result
+        assert "not in allowlist" in result["error"]
+
+    async def test_output_truncation_from_yaml(
+        self, hass, executor, exposed_entities, llm_context
+    ):
+        """Test that long output is truncated from yaml."""
+        func_def = get_function_from_yaml("bash_example.yaml", 10)
+        function_executor = get_function_executor(func_def["function"]["type"])
+        processed_function = function_executor.to_arguments(func_def["function"])
+
+        arguments = {}
+
+        result = await executor.execute(
+            hass, processed_function, arguments, llm_context, exposed_entities
+        )
+
+        assert result["exit_code"] == 0
+        assert "truncated" in result["stdout"].lower()
+        assert len(result["stdout"]) < 12000  # SHELL_OUTPUT_LIMIT is 10000
+
+    async def test_rm_rf_blocked_from_yaml(
+        self, hass, executor, exposed_entities, llm_context
+    ):
+        """Test that rm -rf command is blocked from yaml."""
+        func_def = get_function_from_yaml("bash_example.yaml", 5)
+        function_executor = get_function_executor(func_def["function"]["type"])
+        processed_function = function_executor.to_arguments(func_def["function"])
+
+        arguments = {}
+
+        result = await executor.execute(
+            hass, processed_function, arguments, llm_context, exposed_entities
+        )
+
+        assert "error" in result
+        assert "blocked" in result["error"].lower()
+
+    async def test_disk_wipe_blocked_from_yaml(
+        self, hass, executor, exposed_entities, llm_context
+    ):
+        """Test that dd disk wipe command is blocked from yaml."""
+        func_def = get_function_from_yaml("bash_example.yaml", 7)
+        function_executor = get_function_executor(func_def["function"]["type"])
+        processed_function = function_executor.to_arguments(func_def["function"])
+
+        arguments = {}
+
+        result = await executor.execute(
+            hass, processed_function, arguments, llm_context, exposed_entities
+        )
+
+        assert "error" in result
+        assert "blocked" in result["error"].lower()
+
+    async def test_path_traversal_attack_blocked_from_yaml(
+        self, hass, executor, exposed_entities, llm_context
+    ):
+        """Test that path traversal attack is blocked from yaml."""
+        func_def = get_function_from_yaml("bash_example.yaml", 8)
+        function_executor = get_function_executor(func_def["function"]["type"])
+        processed_function = function_executor.to_arguments(func_def["function"])
+
+        arguments = {}
+
+        result = await executor.execute(
+            hass, processed_function, arguments, llm_context, exposed_entities
+        )
+
+        assert "error" in result
+        assert "traversal" in result["error"].lower()
+
+    async def test_get_function_executor(self):
+        """Test getting bash executor from registry."""
+        executor = get_function_executor("bash")
+        assert isinstance(executor, BashFunctionExecutor)

--- a/tests/function_executors/test_edit_file.py
+++ b/tests/function_executors/test_edit_file.py
@@ -1,0 +1,318 @@
+"""Tests for EditFileFunctionExecutor using yaml definitions."""
+
+import pytest
+
+from custom_components.extended_openai_conversation.helpers import (
+    EditFileFunctionExecutor,
+    get_function_executor,
+)
+from tests.helpers import get_function_from_yaml
+
+
+class TestEditFileFunctionExecutorYaml:
+    """Test EditFileFunctionExecutor using yaml definitions."""
+
+    @pytest.fixture
+    def executor(self):
+        """Create EditFileFunctionExecutor instance."""
+        return EditFileFunctionExecutor()
+
+    async def test_edit_file_success_from_yaml(
+        self, hass, executor, exposed_entities, llm_context, tmp_path
+    ):
+        """Test editing a file successfully from yaml definition."""
+        workdir = tmp_path / "extended_openai_conversation"
+        test_file = workdir / "edit_test.txt"
+        test_file.write_text("Hello World\nThis is a test.")
+
+        func_def = get_function_from_yaml("edit_file_example.yaml", 0)
+        function_executor = get_function_executor(func_def["function"]["type"])
+        processed_function = function_executor.to_arguments(func_def["function"])
+
+        arguments = {
+            "filename": "edit_test.txt",
+            "old_text": "Hello World",
+            "new_text": "Goodbye World",
+        }
+
+        result = await executor.execute(
+            hass, processed_function, arguments, llm_context, exposed_entities
+        )
+
+        assert result["success"] is True
+        assert "path" in result
+        assert result["replacements"] == 1
+
+        new_content = test_file.read_text()
+        assert "Goodbye World" in new_content
+        assert "Hello World" not in new_content
+        assert "This is a test." in new_content
+
+    async def test_edit_file_multiline_replacement_from_yaml(
+        self, hass, executor, exposed_entities, llm_context, tmp_path
+    ):
+        """Test editing multiple lines from yaml."""
+        workdir = tmp_path / "extended_openai_conversation"
+        test_file = workdir / "multiline.txt"
+        test_file.write_text("Line 1\nLine 2\nLine 3\nLine 4")
+
+        func_def = get_function_from_yaml("edit_file_example.yaml", 0)
+        function_executor = get_function_executor(func_def["function"]["type"])
+        processed_function = function_executor.to_arguments(func_def["function"])
+
+        arguments = {
+            "filename": "multiline.txt",
+            "old_text": "Line 2\nLine 3",
+            "new_text": "New Line 2\nNew Line 3",
+        }
+
+        result = await executor.execute(
+            hass, processed_function, arguments, llm_context, exposed_entities
+        )
+
+        assert result["success"] is True
+        new_content = test_file.read_text()
+        assert "New Line 2\nNew Line 3" in new_content
+        assert "Line 2\nLine 3" not in new_content
+
+    async def test_edit_file_not_found(
+        self, hass, executor, exposed_entities, llm_context
+    ):
+        """Test editing a file that doesn't exist."""
+        func_def = get_function_from_yaml("edit_file_example.yaml", 0)
+        function_executor = get_function_executor(func_def["function"]["type"])
+        processed_function = function_executor.to_arguments(func_def["function"])
+
+        arguments = {
+            "filename": "nonexistent.txt",
+            "old_text": "old",
+            "new_text": "new",
+        }
+
+        result = await executor.execute(
+            hass, processed_function, arguments, llm_context, exposed_entities
+        )
+
+        assert "error" in result
+        assert "not found" in result["error"].lower()
+
+    async def test_edit_file_text_not_found(
+        self, hass, executor, exposed_entities, llm_context, tmp_path
+    ):
+        """Test editing when old_text doesn't exist in file."""
+        workdir = tmp_path / "extended_openai_conversation"
+        test_file = workdir / "test.txt"
+        test_file.write_text("Some content without the searched text")
+
+        func_def = get_function_from_yaml("edit_file_example.yaml", 0)
+        function_executor = get_function_executor(func_def["function"]["type"])
+        processed_function = function_executor.to_arguments(func_def["function"])
+
+        arguments = {
+            "filename": "test.txt",
+            "old_text": "Not in file",
+            "new_text": "new text",
+        }
+
+        result = await executor.execute(
+            hass, processed_function, arguments, llm_context, exposed_entities
+        )
+
+        assert "error" in result
+        assert "not found in file" in result["error"].lower()
+
+    async def test_edit_file_multiple_occurrences(
+        self, hass, executor, exposed_entities, llm_context, tmp_path
+    ):
+        """Test that multiple occurrences are rejected."""
+        workdir = tmp_path / "extended_openai_conversation"
+        test_file = workdir / "duplicate.txt"
+        test_file.write_text("Hello\nHello\nGoodbye")
+
+        func_def = get_function_from_yaml("edit_file_example.yaml", 0)
+        function_executor = get_function_executor(func_def["function"]["type"])
+        processed_function = function_executor.to_arguments(func_def["function"])
+
+        arguments = {
+            "filename": "duplicate.txt",
+            "old_text": "Hello",
+            "new_text": "Hi",
+        }
+
+        result = await executor.execute(
+            hass, processed_function, arguments, llm_context, exposed_entities
+        )
+
+        assert "error" in result
+        assert "2 times" in result["error"]
+        assert test_file.read_text() == "Hello\nHello\nGoodbye"
+
+    async def test_edit_file_is_directory(
+        self, hass, executor, exposed_entities, llm_context, tmp_path
+    ):
+        """Test editing a directory instead of file."""
+        workdir = tmp_path / "extended_openai_conversation"
+        test_dir = workdir / "testdir"
+        test_dir.mkdir()
+
+        func_def = get_function_from_yaml("edit_file_example.yaml", 0)
+        function_executor = get_function_executor(func_def["function"]["type"])
+        processed_function = function_executor.to_arguments(func_def["function"])
+
+        arguments = {
+            "filename": "testdir",
+            "old_text": "old",
+            "new_text": "new",
+        }
+
+        result = await executor.execute(
+            hass, processed_function, arguments, llm_context, exposed_entities
+        )
+
+        assert "error" in result
+        assert "not a file" in result["error"].lower()
+
+    async def test_edit_file_outside_allowed_dir(
+        self, hass, executor, exposed_entities, llm_context, tmp_path
+    ):
+        """Test that editing files outside allowed directories is blocked."""
+        external_file = tmp_path / "external.txt"
+        external_file.write_text("External content")
+
+        func_def = get_function_from_yaml("edit_file_example.yaml", 0)
+        function_executor = get_function_executor(func_def["function"]["type"])
+        processed_function = function_executor.to_arguments(func_def["function"])
+
+        arguments = {
+            "filename": str(external_file),
+            "old_text": "External",
+            "new_text": "Modified",
+        }
+
+        result = await executor.execute(
+            hass, processed_function, arguments, llm_context, exposed_entities
+        )
+
+        assert "error" in result
+        assert ("access denied" in result["error"].lower() or
+                "not in allowed" in result["error"].lower())
+        assert external_file.read_text() == "External content"
+
+    async def test_edit_file_with_custom_allow_dir_from_yaml(
+        self, hass, executor, exposed_entities, llm_context
+    ):
+        """Test editing file in custom allowed directory from yaml."""
+        import os
+
+        # Use /tmp directory as specified in yaml
+        test_file_path = os.path.join("/tmp", "custom_edit_test.txt")
+
+        with open(test_file_path, "w") as f:
+            f.write("Original text")
+
+        try:
+            func_def = get_function_from_yaml("edit_file_example.yaml", 1)
+            function_executor = get_function_executor(func_def["function"]["type"])
+            processed_function = function_executor.to_arguments(func_def["function"])
+
+            arguments = {
+                "filepath": test_file_path,
+                "old_text": "Original",
+                "new_text": "Modified",
+            }
+
+            result = await executor.execute(
+                hass, processed_function, arguments, llm_context, exposed_entities
+            )
+
+            assert result["success"] is True
+            with open(test_file_path) as f:
+                assert f.read() == "Modified text"
+        finally:
+            # Clean up
+            if os.path.exists(test_file_path):
+                os.remove(test_file_path)
+
+    async def test_edit_file_template_path(
+        self, hass, executor, exposed_entities, llm_context, tmp_path
+    ):
+        """Test editing file with templated path."""
+        workdir = tmp_path / "extended_openai_conversation"
+        test_file = workdir / "templated.txt"
+        test_file.write_text("Template test")
+
+        func_def = get_function_from_yaml("edit_file_example.yaml", 0)
+        function_executor = get_function_executor(func_def["function"]["type"])
+        processed_function = function_executor.to_arguments(func_def["function"])
+
+        arguments = {
+            "filename": "templated.txt",
+            "old_text": "Template",
+            "new_text": "Replaced",
+        }
+
+        result = await executor.execute(
+            hass, processed_function, arguments, llm_context, exposed_entities
+        )
+
+        assert result["success"] is True
+        assert test_file.read_text() == "Replaced test"
+
+    async def test_edit_file_unicode_content_from_yaml(
+        self, hass, executor, exposed_entities, llm_context, tmp_path
+    ):
+        """Test editing file with unicode content from yaml."""
+        workdir = tmp_path / "extended_openai_conversation"
+        test_file = workdir / "unicode.txt"
+        test_file.write_text("Hello 世界", encoding="utf-8")
+
+        func_def = get_function_from_yaml("edit_file_example.yaml", 2)
+        function_executor = get_function_executor(func_def["function"]["type"])
+        processed_function = function_executor.to_arguments(func_def["function"])
+
+        arguments = {
+            "filename": "unicode.txt",
+            "old_text": "世界",
+            "new_text": "World",
+        }
+
+        result = await executor.execute(
+            hass, processed_function, arguments, llm_context, exposed_entities
+        )
+
+        assert result["success"] is True
+        assert test_file.read_text(encoding="utf-8") == "Hello World"
+
+    async def test_edit_file_preserves_rest_of_content(
+        self, hass, executor, exposed_entities, llm_context, tmp_path
+    ):
+        """Test that edit preserves content before and after replacement."""
+        workdir = tmp_path / "extended_openai_conversation"
+        test_file = workdir / "preserve.txt"
+        test_file.write_text("Start\nMiddle line to replace\nEnd")
+
+        func_def = get_function_from_yaml("edit_file_example.yaml", 0)
+        function_executor = get_function_executor(func_def["function"]["type"])
+        processed_function = function_executor.to_arguments(func_def["function"])
+
+        arguments = {
+            "filename": "preserve.txt",
+            "old_text": "Middle line to replace",
+            "new_text": "New middle line",
+        }
+
+        result = await executor.execute(
+            hass, processed_function, arguments, llm_context, exposed_entities
+        )
+
+        assert result["success"] is True
+        new_content = test_file.read_text()
+        assert "Start" in new_content
+        assert "New middle line" in new_content
+        assert "End" in new_content
+        assert "Middle line to replace" not in new_content
+
+    async def test_get_function_executor(self):
+        """Test getting edit_file executor from registry."""
+        executor = get_function_executor("edit_file")
+        assert isinstance(executor, EditFileFunctionExecutor)

--- a/tests/function_executors/test_read_file.py
+++ b/tests/function_executors/test_read_file.py
@@ -1,0 +1,257 @@
+"""Tests for ReadFileFunctionExecutor using yaml definitions."""
+
+import pytest
+
+from custom_components.extended_openai_conversation.helpers import (
+    ReadFileFunctionExecutor,
+    get_function_executor,
+)
+from tests.helpers import get_function_from_yaml
+
+
+class TestReadFileFunctionExecutorYaml:
+    """Test ReadFileFunctionExecutor using yaml definitions."""
+
+    @pytest.fixture
+    def executor(self):
+        """Create ReadFileFunctionExecutor instance."""
+        return ReadFileFunctionExecutor()
+
+    async def test_read_file_success_from_yaml(
+        self, hass, executor, exposed_entities, llm_context, tmp_path
+    ):
+        """Test reading a file successfully from yaml definition."""
+        workdir = tmp_path / "extended_openai_conversation"
+        test_file = workdir / "test.txt"
+        test_content = "Hello, World!\nThis is a test file."
+        test_file.write_text(test_content)
+
+        func_def = get_function_from_yaml("read_file_example.yaml", 0)
+        function_executor = get_function_executor(func_def["function"]["type"])
+        processed_function = function_executor.to_arguments(func_def["function"])
+
+        arguments = {"filename": "test.txt"}
+
+        result = await executor.execute(
+            hass, processed_function, arguments, llm_context, exposed_entities
+        )
+
+        assert "content" in result
+        assert result["content"] == test_content
+        assert "size" in result
+        assert result["size"] == len(test_content.encode("utf-8"))
+
+    async def test_read_file_absolute_path_from_yaml(
+        self, hass, executor, exposed_entities, llm_context, tmp_path
+    ):
+        """Test reading file with absolute path from yaml."""
+        workdir = tmp_path / "extended_openai_conversation"
+        test_file = workdir / "absolute_test.txt"
+        test_content = "Absolute path test"
+        test_file.write_text(test_content)
+
+        func_def = get_function_from_yaml("read_file_example.yaml", 1)
+        function_executor = get_function_executor(func_def["function"]["type"])
+        processed_function = function_executor.to_arguments(func_def["function"])
+
+        arguments = {"filepath": str(test_file)}
+
+        result = await executor.execute(
+            hass, processed_function, arguments, llm_context, exposed_entities
+        )
+
+        assert "content" in result
+        assert result["content"] == test_content
+
+    async def test_read_file_not_found(
+        self, hass, executor, exposed_entities, llm_context
+    ):
+        """Test reading a file that doesn't exist."""
+        func_def = get_function_from_yaml("read_file_example.yaml", 0)
+        function_executor = get_function_executor(func_def["function"]["type"])
+        processed_function = function_executor.to_arguments(func_def["function"])
+
+        arguments = {"filename": "nonexistent.txt"}
+
+        result = await executor.execute(
+            hass, processed_function, arguments, llm_context, exposed_entities
+        )
+
+        assert "error" in result
+        assert "not found" in result["error"].lower()
+
+    async def test_read_file_is_directory(
+        self, hass, executor, exposed_entities, llm_context, tmp_path
+    ):
+        """Test reading a directory instead of file."""
+        workdir = tmp_path / "extended_openai_conversation"
+        test_dir = workdir / "testdir"
+        test_dir.mkdir()
+
+        func_def = get_function_from_yaml("read_file_example.yaml", 0)
+        function_executor = get_function_executor(func_def["function"]["type"])
+        processed_function = function_executor.to_arguments(func_def["function"])
+
+        arguments = {"filename": "testdir"}
+
+        result = await executor.execute(
+            hass, processed_function, arguments, llm_context, exposed_entities
+        )
+
+        assert "error" in result
+        assert "not a file" in result["error"].lower()
+
+    async def test_read_file_too_large(
+        self, hass, executor, exposed_entities, llm_context, tmp_path
+    ):
+        """Test reading a file that exceeds size limit."""
+        workdir = tmp_path / "extended_openai_conversation"
+        workdir.mkdir(parents=True, exist_ok=True)
+        test_file = workdir / "large.txt"
+
+        # Create a file larger than FILE_READ_SIZE_LIMIT (1 MB)
+        large_content = "A" * (1024 * 1024 + 100)
+        test_file.write_text(large_content)
+
+        func_def = get_function_from_yaml("read_file_example.yaml", 0)
+        function_executor = get_function_executor(func_def["function"]["type"])
+        processed_function = function_executor.to_arguments(func_def["function"])
+
+        arguments = {"filename": "large.txt"}
+
+        result = await executor.execute(
+            hass, processed_function, arguments, llm_context, exposed_entities
+        )
+
+        assert "error" in result
+        assert "too large" in result["error"].lower()
+
+    async def test_read_file_outside_allowed_dir(
+        self, hass, executor, exposed_entities, llm_context, tmp_path
+    ):
+        """Test that reading files outside allowed directories is blocked."""
+        external_file = tmp_path / "external.txt"
+        external_file.write_text("This should not be accessible")
+
+        func_def = get_function_from_yaml("read_file_example.yaml", 1)
+        function_executor = get_function_executor(func_def["function"]["type"])
+        processed_function = function_executor.to_arguments(func_def["function"])
+
+        arguments = {"filepath": str(external_file)}
+
+        result = await executor.execute(
+            hass, processed_function, arguments, llm_context, exposed_entities
+        )
+
+        assert "error" in result
+        assert ("access denied" in result["error"].lower() or
+                "not in allowed" in result["error"].lower())
+
+    async def test_read_file_absolute_path_outside_working_directory_from_yaml(
+        self, hass, executor, exposed_entities, llm_context, tmp_path
+    ):
+        """Test reading file with absolute path outside working directory from yaml."""
+        # Create a file outside the working directory
+        external_dir = tmp_path / "external"
+        external_dir.mkdir()
+        test_file = external_dir / "external_test.txt"
+        test_content = "External file content"
+        test_file.write_text(test_content)
+
+        func_def = get_function_from_yaml("read_file_example.yaml", 2)
+        function_executor = get_function_executor(func_def["function"]["type"])
+        processed_function = function_executor.to_arguments(func_def["function"])
+
+        arguments = {"filepath": str(test_file)}
+
+        result = await executor.execute(
+            hass, processed_function, arguments, llm_context, exposed_entities
+        )
+
+        # This should fail because the file is outside the allowed directory
+        assert "error" in result
+        assert ("access denied" in result["error"].lower() or
+                "not in allowed" in result["error"].lower())
+
+    async def test_read_file_with_custom_allow_dir_from_yaml(
+        self, hass, executor, exposed_entities, llm_context
+    ):
+        """Test reading file from custom allowed directory from yaml."""
+        import tempfile
+        import os
+
+        # Use /tmp directory as specified in yaml
+        test_file_path = os.path.join("/tmp", "custom_read_test.txt")
+        test_content = "Custom directory content"
+
+        with open(test_file_path, "w") as f:
+            f.write(test_content)
+
+        try:
+            func_def = get_function_from_yaml("read_file_example.yaml", 3)
+            function_executor = get_function_executor(func_def["function"]["type"])
+            processed_function = function_executor.to_arguments(func_def["function"])
+
+            arguments = {
+                "filepath": test_file_path,
+            }
+
+            result = await executor.execute(
+                hass, processed_function, arguments, llm_context, exposed_entities
+            )
+
+            assert "content" in result
+            assert result["content"] == test_content
+        finally:
+            # Clean up
+            if os.path.exists(test_file_path):
+                os.remove(test_file_path)
+
+    async def test_read_file_template_path(
+        self, hass, executor, exposed_entities, llm_context, tmp_path
+    ):
+        """Test reading file with templated path."""
+        workdir = tmp_path / "extended_openai_conversation"
+        test_file = workdir / "templated.txt"
+        test_content = "Hello, World!\nThis is a test file."
+        test_file.write_text(test_content)
+
+        func_def = get_function_from_yaml("read_file_example.yaml", 0)
+        function_executor = get_function_executor(func_def["function"]["type"])
+        processed_function = function_executor.to_arguments(func_def["function"])
+
+        arguments = {"filename": "templated.txt"}
+
+        result = await executor.execute(
+            hass, processed_function, arguments, llm_context, exposed_entities
+        )
+
+        assert "content" in result
+        assert result["content"] == test_content
+
+    async def test_read_file_unicode_content_from_yaml(
+        self, hass, executor, exposed_entities, llm_context, tmp_path
+    ):
+        """Test reading file with unicode content from yaml."""
+        workdir = tmp_path / "extended_openai_conversation"
+        test_file = workdir / "unicode.txt"
+        test_content = "Hello 世界 🌍 مرحبا"
+        test_file.write_text(test_content, encoding="utf-8")
+
+        func_def = get_function_from_yaml("read_file_example.yaml", 4)
+        function_executor = get_function_executor(func_def["function"]["type"])
+        processed_function = function_executor.to_arguments(func_def["function"])
+
+        arguments = {}
+
+        result = await executor.execute(
+            hass, processed_function, arguments, llm_context, exposed_entities
+        )
+
+        assert "content" in result
+        assert result["content"] == test_content
+
+    async def test_get_function_executor(self):
+        """Test getting read_file executor from registry."""
+        executor = get_function_executor("read_file")
+        assert isinstance(executor, ReadFileFunctionExecutor)

--- a/tests/function_executors/test_write_file.py
+++ b/tests/function_executors/test_write_file.py
@@ -1,0 +1,230 @@
+"""Tests for WriteFileFunctionExecutor using yaml definitions."""
+
+import pytest
+
+from custom_components.extended_openai_conversation.helpers import (
+    WriteFileFunctionExecutor,
+    get_function_executor,
+)
+from tests.helpers import get_function_from_yaml
+
+
+class TestWriteFileFunctionExecutorYaml:
+    """Test WriteFileFunctionExecutor using yaml definitions."""
+
+    @pytest.fixture
+    def executor(self):
+        """Create WriteFileFunctionExecutor instance."""
+        return WriteFileFunctionExecutor()
+
+    async def test_write_file_success_from_yaml(
+        self, hass, executor, exposed_entities, llm_context, tmp_path
+    ):
+        """Test writing a file successfully from yaml definition."""
+        workdir = tmp_path / "extended_openai_conversation"
+        test_file = workdir / "new_file.txt"
+
+        func_def = get_function_from_yaml("write_file_example.yaml", 0)
+        function_executor = get_function_executor(func_def["function"]["type"])
+        processed_function = function_executor.to_arguments(func_def["function"])
+
+        test_content = "This is new content"
+        arguments = {"filename": "new_file.txt", "content": test_content}
+
+        result = await executor.execute(
+            hass, processed_function, arguments, llm_context, exposed_entities
+        )
+
+        assert result["success"] is True
+        assert "path" in result
+        assert "bytes_written" in result
+        assert result["bytes_written"] == len(test_content.encode("utf-8"))
+        assert test_file.exists()
+        assert test_file.read_text() == test_content
+
+    async def test_write_file_overwrite_from_yaml(
+        self, hass, executor, exposed_entities, llm_context, tmp_path
+    ):
+        """Test overwriting an existing file from yaml."""
+        workdir = tmp_path / "extended_openai_conversation"
+        test_file = workdir / "existing.txt"
+        test_file.write_text("old content")
+
+        func_def = get_function_from_yaml("write_file_example.yaml", 0)
+        function_executor = get_function_executor(func_def["function"]["type"])
+        processed_function = function_executor.to_arguments(func_def["function"])
+
+        new_content = "New content"
+        arguments = {"filename": "existing.txt", "content": new_content}
+
+        result = await executor.execute(
+            hass, processed_function, arguments, llm_context, exposed_entities
+        )
+
+        assert result["success"] is True
+        assert test_file.read_text() == new_content
+
+    async def test_write_file_absolute_path_from_yaml(
+        self, hass, executor, exposed_entities, llm_context, tmp_path
+    ):
+        """Test writing file with absolute path from yaml."""
+        workdir = tmp_path / "extended_openai_conversation"
+        test_file = workdir / "absolute.txt"
+
+        func_def = get_function_from_yaml("write_file_example.yaml", 1)
+        function_executor = get_function_executor(func_def["function"]["type"])
+        processed_function = function_executor.to_arguments(func_def["function"])
+
+        test_content = "Absolute path content"
+        arguments = {"filepath": str(test_file), "content": test_content}
+
+        result = await executor.execute(
+            hass, processed_function, arguments, llm_context, exposed_entities
+        )
+
+        assert result["success"] is True
+        assert test_file.read_text() == test_content
+
+    async def test_write_file_outside_allowed_dir(
+        self, hass, executor, exposed_entities, llm_context, tmp_path
+    ):
+        """Test that writing files outside allowed directories is blocked."""
+        external_file = tmp_path / "external.txt"
+
+        func_def = get_function_from_yaml("write_file_example.yaml", 1)
+        function_executor = get_function_executor(func_def["function"]["type"])
+        processed_function = function_executor.to_arguments(func_def["function"])
+
+        arguments = {
+            "filepath": str(external_file),
+            "content": "This should not be written",
+        }
+
+        result = await executor.execute(
+            hass, processed_function, arguments, llm_context, exposed_entities
+        )
+
+        assert "error" in result
+        assert ("access denied" in result["error"].lower() or
+                "not in allowed" in result["error"].lower())
+        assert not external_file.exists()
+
+    async def test_write_file_with_custom_allow_dir_from_yaml(
+        self, hass, executor, exposed_entities, llm_context
+    ):
+        """Test writing file to custom allowed directory from yaml."""
+        import os
+
+        # Use /tmp directory as specified in yaml
+        test_file_path = os.path.join("/tmp", "custom_write_test.txt")
+
+        try:
+            func_def = get_function_from_yaml("write_file_example.yaml", 2)
+            function_executor = get_function_executor(func_def["function"]["type"])
+            processed_function = function_executor.to_arguments(func_def["function"])
+
+            test_content = "Custom directory write"
+            arguments = {
+                "filepath": test_file_path,
+                "content": test_content,
+            }
+
+            result = await executor.execute(
+                hass, processed_function, arguments, llm_context, exposed_entities
+            )
+
+            assert result["success"] is True
+            with open(test_file_path) as f:
+                assert f.read() == test_content
+        finally:
+            # Clean up
+            if os.path.exists(test_file_path):
+                os.remove(test_file_path)
+
+    async def test_write_file_template_path(
+        self, hass, executor, exposed_entities, llm_context, tmp_path
+    ):
+        """Test writing file with templated path."""
+        workdir = tmp_path / "extended_openai_conversation"
+        test_file = workdir / "templated.txt"
+
+        func_def = get_function_from_yaml("write_file_example.yaml", 0)
+        function_executor = get_function_executor(func_def["function"]["type"])
+        processed_function = function_executor.to_arguments(func_def["function"])
+
+        arguments = {"filename": "templated.txt", "content": "Templated content"}
+
+        result = await executor.execute(
+            hass, processed_function, arguments, llm_context, exposed_entities
+        )
+
+        assert result["success"] is True
+        assert test_file.read_text() == "Templated content"
+
+    async def test_write_file_unicode_content_from_yaml(
+        self, hass, executor, exposed_entities, llm_context, tmp_path
+    ):
+        """Test writing file with unicode content from yaml."""
+        workdir = tmp_path / "extended_openai_conversation"
+        test_file = workdir / "unicode.txt"
+
+        func_def = get_function_from_yaml("write_file_example.yaml", 3)
+        function_executor = get_function_executor(func_def["function"]["type"])
+        processed_function = function_executor.to_arguments(func_def["function"])
+
+        test_content = "Hello 世界 🌍 مرحبا"
+        arguments = {"filename": "unicode.txt", "content": test_content}
+
+        result = await executor.execute(
+            hass, processed_function, arguments, llm_context, exposed_entities
+        )
+
+        assert result["success"] is True
+        assert test_file.read_text(encoding="utf-8") == test_content
+
+    async def test_write_file_empty_content_from_yaml(
+        self, hass, executor, exposed_entities, llm_context, tmp_path
+    ):
+        """Test writing file with empty content from yaml."""
+        workdir = tmp_path / "extended_openai_conversation"
+        test_file = workdir / "empty.txt"
+
+        func_def = get_function_from_yaml("write_file_example.yaml", 4)
+        function_executor = get_function_executor(func_def["function"]["type"])
+        processed_function = function_executor.to_arguments(func_def["function"])
+
+        arguments = {"filename": "empty.txt", "content": ""}
+
+        result = await executor.execute(
+            hass, processed_function, arguments, llm_context, exposed_entities
+        )
+
+        assert result["success"] is True
+        assert result["bytes_written"] == 0
+        assert test_file.read_text() == ""
+
+    async def test_write_file_multiline_content_from_yaml(
+        self, hass, executor, exposed_entities, llm_context, tmp_path
+    ):
+        """Test writing file with multiline content from yaml."""
+        workdir = tmp_path / "extended_openai_conversation"
+        test_file = workdir / "multiline.txt"
+
+        func_def = get_function_from_yaml("write_file_example.yaml", 5)
+        function_executor = get_function_executor(func_def["function"]["type"])
+        processed_function = function_executor.to_arguments(func_def["function"])
+
+        test_content = "Line 1\nLine 2\nLine 3"
+        arguments = {"filename": "multiline.txt", "content": test_content}
+
+        result = await executor.execute(
+            hass, processed_function, arguments, llm_context, exposed_entities
+        )
+
+        assert result["success"] is True
+        assert test_file.read_text() == test_content
+
+    async def test_get_function_executor(self):
+        """Test getting write_file executor from registry."""
+        executor = get_function_executor("write_file")
+        assert isinstance(executor, WriteFileFunctionExecutor)


### PR DESCRIPTION
## Objective
- Add skills to make [progressive disclosure](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices#progressive-disclosure-patterns) of context possible.

## Changes
<img width="400" src="https://github.com/user-attachments/assets/3f12ded0-60c5-42a6-8618-ca21dc927f88" />

- Add Skills feature
  - skills directory: `/config/extended_openai_conversation/skills`
  - Fix default system prompt and functions
    - To keep system prompt simple like [nanobot](https://github.com/HKUDS/nanobot/blob/main/nanobot/agent/context.py)
    - "skills" property is added in system prompt.
    - Use "load_skill" and "bash" to load skills and execute scripts in skills


- Add 4 functions (inspired by [pi](https://mariozechner.at/posts/2025-11-30-pi-coding-agent/), [openclaw](https://github.com/openclaw/openclaw), [nanobot](https://github.com/HKUDS/nanobot))
  - read_file
  - write_file
  - edit_file
  - bash

## Caveat
- Since skill scripts can contain anything, it may be harmful if misused.
  - Refer "Security considerations when using Skills" section in this [page](https://claude.com/blog/equipping-agents-for-the-real-world-with-agent-skills)

## Workspace & Security
Four functions (read_file, write_file, edit_file, bash) are based on working directory (`<config>/extended_openai_conversation`) by default.
It's restricted to use command in working directory by default.

## References
- https://github.com/HKUDS/nanobot