### PR TITLE
Fix CI linting errors and refactor test imports

### DIFF
--- a/custom_components/extended_openai_conversation/config_flow.py
+++ b/custom_components/extended_openai_conversation/config_flow.py
@@ -435,9 +435,7 @@ class ExtendedOpenAISubentryFlowHandler(ConfigSubentryFlow):
             ): SelectSelector(
                 SelectSelectorConfig(
                     options=[
-                        SelectOptionDict(
-                            value=strategy["key"], label=strategy["label"]
-                        )
+                        SelectOptionDict(value=strategy["key"], label=strategy["label"])
                         for strategy in CONTEXT_TRUNCATE_STRATEGIES
                     ],
                     mode=SelectSelectorMode.DROPDOWN,

--- a/custom_components/extended_openai_conversation/conversation.py
+++ b/custom_components/extended_openai_conversation/conversation.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, Literal, cast
 
 from homeassistant.components import conversation
 from homeassistant.components.conversation import (
@@ -39,7 +39,7 @@ from .const import (
 from .entity import ExtendedOpenAIBaseLLMEntity
 from .exceptions import FunctionLoadFailed, FunctionNotFound, InvalidFunction
 from .helpers import get_exposed_entities, get_function_executor
-from .skills import SkillManager
+from .skills import Skill, SkillManager
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -86,7 +86,7 @@ class ExtendedOpenAIAgentEntity(
     @property
     def skills(self) -> list[str]:
         """Get the enabled skills list for this entity."""
-        return self.subentry.data.get(CONF_SKILLS, [])
+        return cast(list[str], self.subentry.data.get(CONF_SKILLS, []))
 
     async def async_added_to_hass(self) -> None:
         """When entity is added to Home Assistant."""
@@ -216,9 +216,9 @@ class ExtendedOpenAIAgentEntity(
             parse_result=False,
         )
 
-        return rendered_prompt
+        return cast(str, rendered_prompt)
 
-    def _get_enabled_skills(self) -> list[dict]:
+    def _get_enabled_skills(self) -> list[Skill]:
         """Get enabled skills as list of dicts for template rendering."""
         enabled_skill_names = self.skills
         all_skills = self.skill_manager.get_all_skills()
@@ -228,12 +228,14 @@ class ExtendedOpenAIAgentEntity(
     def _get_exposed_entities(self) -> list[dict[str, Any]]:
         return get_exposed_entities(self.hass)
 
-    def _get_functions(self) -> list[dict]:
+    def _get_functions(self) -> list[dict[str, Any]]:
         """Get custom functions configuration including skill functions."""
         try:
             function = self.subentry.data.get(CONF_FUNCTIONS)
             result = yaml.safe_load(function) if function else DEFAULT_CONF_FUNCTIONS
+            # Ensure result is a list of dicts
             if result:
+                result = cast(list[dict[str, Any]], result)
                 for setting in result:
                     if isinstance(setting, dict) and "function" in setting:
                         function_data = setting["function"]
@@ -244,7 +246,7 @@ class ExtendedOpenAIAgentEntity(
                             setting["function"] = function_executor.to_arguments(
                                 function_data
                             )
-            result = result or []
+            result = cast(list[dict[str, Any]], result or [])
 
             # Add skill functions
             skill_functions = self.skill_manager.get_skill_functions(

--- a/custom_components/extended_openai_conversation/conversation.py
+++ b/custom_components/extended_openai_conversation/conversation.py
@@ -249,15 +249,19 @@ class ExtendedOpenAIAgentEntity(
             result = cast(list[dict[str, Any]], result or [])
 
             # Add skill functions
-            skill_functions = self.skill_manager.get_skill_functions(
-                self.skills,
-                working_directory=DEFAULT_WORKING_DIRECTORY,
+            skill_functions = cast(
+                list[dict[str, Any]],
+                self.skill_manager.get_skill_functions(
+                    self.skills,
+                    working_directory=DEFAULT_WORKING_DIRECTORY,
+                ),
             )
             for setting in skill_functions:
-                function_executor = get_function_executor(setting["function"]["type"])
-                setting["function"] = function_executor.to_arguments(
-                    setting["function"]
+                function_data = cast(dict[str, Any], setting["function"])
+                function_executor = get_function_executor(
+                    cast(str, function_data["type"])
                 )
+                setting["function"] = function_executor.to_arguments(function_data)
             result.extend(skill_functions)
 
             return result

--- a/custom_components/extended_openai_conversation/conversation.py
+++ b/custom_components/extended_openai_conversation/conversation.py
@@ -216,10 +216,7 @@ class ExtendedOpenAIAgentEntity(
             parse_result=False,
         )
 
-        if not isinstance(rendered_prompt, str):
-            raise TypeError("System prompt template did not render to a string")
-
-        return rendered_prompt
+        return str(rendered_prompt)
 
     def _get_enabled_skills(self) -> list[Skill]:
         """Get enabled skills as list of dicts for template rendering."""

--- a/custom_components/extended_openai_conversation/conversation.py
+++ b/custom_components/extended_openai_conversation/conversation.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import Any, Literal, cast
+from typing import Any, Literal
 
 from homeassistant.components import conversation
 from homeassistant.components.conversation import (
@@ -86,7 +86,7 @@ class ExtendedOpenAIAgentEntity(
     @property
     def skills(self) -> list[str]:
         """Get the enabled skills list for this entity."""
-        return cast(list[str], self.subentry.data.get(CONF_SKILLS, []))
+        return self.subentry.data.get(CONF_SKILLS, []) or []
 
     async def async_added_to_hass(self) -> None:
         """When entity is added to Home Assistant."""
@@ -216,7 +216,10 @@ class ExtendedOpenAIAgentEntity(
             parse_result=False,
         )
 
-        return cast(str, rendered_prompt)
+        if not isinstance(rendered_prompt, str):
+            raise TypeError("System prompt template did not render to a string")
+
+        return rendered_prompt
 
     def _get_enabled_skills(self) -> list[Skill]:
         """Get enabled skills as list of dicts for template rendering."""
@@ -232,39 +235,35 @@ class ExtendedOpenAIAgentEntity(
         """Get custom functions configuration including skill functions."""
         try:
             function = self.subentry.data.get(CONF_FUNCTIONS)
-            result = yaml.safe_load(function) if function else DEFAULT_CONF_FUNCTIONS
-            # Ensure result is a list of dicts
+            result: list[dict[str, Any]] | None = (
+                yaml.safe_load(function) if function else DEFAULT_CONF_FUNCTIONS
+            )
             if result:
-                result = cast(list[dict[str, Any]], result)
                 for setting in result:
                     if isinstance(setting, dict) and "function" in setting:
                         function_data = setting["function"]
                         if isinstance(function_data, dict) and "type" in function_data:
                             function_executor = get_function_executor(
-                                function_data["type"]
+                                str(function_data["type"])
                             )
                             setting["function"] = function_executor.to_arguments(
                                 function_data
                             )
-            result = cast(list[dict[str, Any]], result or [])
+
+            final_result: list[dict[str, Any]] = result or []
 
             # Add skill functions
-            skill_functions = cast(
-                list[dict[str, Any]],
-                self.skill_manager.get_skill_functions(
-                    self.skills,
-                    working_directory=DEFAULT_WORKING_DIRECTORY,
-                ),
+            skill_functions = self.skill_manager.get_skill_functions(
+                self.skills,
+                working_directory=DEFAULT_WORKING_DIRECTORY,
             )
             for setting in skill_functions:
-                function_data = cast(dict[str, Any], setting["function"])
-                function_executor = get_function_executor(
-                    cast(str, function_data["type"])
-                )
+                function_data = setting["function"]
+                function_executor = get_function_executor(str(function_data["type"]))
                 setting["function"] = function_executor.to_arguments(function_data)
-            result.extend(skill_functions)
+            final_result.extend(skill_functions)
 
-            return result
+            return final_result
         except (InvalidFunction, FunctionNotFound) as e:
             raise e
         except Exception as e:

--- a/custom_components/extended_openai_conversation/conversation.py
+++ b/custom_components/extended_openai_conversation/conversation.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, Literal
 from pathlib import Path
+from typing import Any, Literal
 
 from homeassistant.components import conversation
 from homeassistant.components.conversation import (

--- a/custom_components/extended_openai_conversation/helpers.py
+++ b/custom_components/extended_openai_conversation/helpers.py
@@ -981,7 +981,9 @@ class BashFunctionExecutor(FunctionExecutor):
         command = arguments.get("command")
 
         # Get configured working directory from function config
-        configured_workdir = function.get("working_directory", DEFAULT_WORKING_DIRECTORY)
+        configured_workdir = function.get(
+            "working_directory", DEFAULT_WORKING_DIRECTORY
+        )
 
         # Resolve relative paths against config directory
         if Path(configured_workdir).is_absolute():
@@ -1018,9 +1020,7 @@ class BashFunctionExecutor(FunctionExecutor):
                 )
             except TimeoutError:
                 process.kill()
-                return {
-                    "error": f"Command timed out after {timeout} seconds"
-                }
+                return {"error": f"Command timed out after {timeout} seconds"}
 
             result = {
                 "exit_code": process.returncode,

--- a/custom_components/extended_openai_conversation/helpers.py
+++ b/custom_components/extended_openai_conversation/helpers.py
@@ -908,7 +908,6 @@ class SkillReadFunctionExecutor(FunctionExecutor):
             Skill instructions or error message
         """
         skill_name = arguments.get("skill_name")
-        skill_args = arguments.get("args")
 
         if not skill_name:
             return {"error": "skill_name is required"}

--- a/custom_components/extended_openai_conversation/skills.py
+++ b/custom_components/extended_openai_conversation/skills.py
@@ -8,9 +8,8 @@ from pathlib import Path
 import re
 from typing import Any
 
-import yaml
-
 from homeassistant.core import HomeAssistant
+import yaml
 
 from .const import DEFAULT_SKILLS_DIRECTORY, DEFAULT_WORKING_DIRECTORY, SKILL_FILE_NAME
 
@@ -276,9 +275,6 @@ class SkillManager:
 
         if not enabled_skills:
             return []
-
-        # Build skill names for description
-        skill_names = ", ".join(f"'{s.name}'" for s in enabled_skills)
 
         return [
             {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 """Fixtures for extended_openai_conversation tests."""
+
 from pathlib import Path
 import sys
 from unittest.mock import AsyncMock, MagicMock

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,16 @@
 """Fixtures for extended_openai_conversation tests."""
-
 from pathlib import Path
+import sys
 from unittest.mock import AsyncMock, MagicMock
 
-from homeassistant.helpers import config_validation as cv
-from homeassistant.helpers.template import TemplateEnvironment
-import pytest
+# Add config directory to path for custom_components imports
+config_dir = Path(__file__).parent.parent
+if str(config_dir) not in sys.path:
+    sys.path.insert(0, str(config_dir))
+
+from homeassistant.helpers import config_validation as cv  # noqa: E402
+from homeassistant.helpers.template import TemplateEnvironment  # noqa: E402
+import pytest  # noqa: E402
 
 
 @pytest.fixture

--- a/tests/function_executors/test_base.py
+++ b/tests/function_executors/test_base.py
@@ -1,17 +1,7 @@
 """Tests for FunctionExecutor base class and helper function."""
 
-import sys
-from pathlib import Path
-
-# Add config directory to path for custom_components imports
-config_dir = Path(__file__).parent.parent.parent.parent.parent
-if str(config_dir) not in sys.path:
-    sys.path.insert(0, str(config_dir))
-
 from unittest.mock import MagicMock
 
-from homeassistant.exceptions import ServiceNotFound
-from homeassistant.helpers.template import Template
 import pytest
 import voluptuous as vol
 
@@ -28,7 +18,6 @@ from custom_components.extended_openai_conversation.helpers import (
     TemplateFunctionExecutor,
     get_function_executor,
 )
-
 
 
 class TestGetFunctionExecutor:
@@ -63,7 +52,6 @@ class TestFunctionExecutorBase:
         executor = TemplateFunctionExecutor()
         # For testing, pass an already-built Template to bypass cv.template validation
         # This tests the schema structure, not the cv.template behavior
-        template = Template("{{ test }}", hass)
         # The executor's schema uses cv.template which validates strings
         # For unit testing, we verify the schema accepts the required keys
         assert (

--- a/tests/function_executors/test_base.py
+++ b/tests/function_executors/test_base.py
@@ -85,5 +85,3 @@ class TestFunctionExecutorBase:
 
         with pytest.raises(EntityNotExposed):
             executor.validate_entity_ids(hass, ["light.not_exposed"], exposed_entities)
-
-

--- a/tests/function_executors/test_composite.py
+++ b/tests/function_executors/test_composite.py
@@ -33,8 +33,12 @@ class TestCompositeFunctionExecutorYaml:
         # Mock sensor states for the living_room
         def mock_states_get(entity_id):
             states_map = {
-                "sensor.living_room_temperature": State("sensor.living_room_temperature", "22.5"),
-                "sensor.living_room_humidity": State("sensor.living_room_humidity", "45"),
+                "sensor.living_room_temperature": State(
+                    "sensor.living_room_temperature", "22.5"
+                ),
+                "sensor.living_room_humidity": State(
+                    "sensor.living_room_humidity", "45"
+                ),
                 "light.living_room": State("light.living_room", "on"),
             }
             return states_map.get(entity_id)
@@ -65,7 +69,9 @@ class TestCompositeFunctionExecutorYaml:
         # Mock sensor states for bedroom
         def mock_states_get(entity_id):
             states_map = {
-                "sensor.bedroom_temperature": State("sensor.bedroom_temperature", "20.0"),
+                "sensor.bedroom_temperature": State(
+                    "sensor.bedroom_temperature", "20.0"
+                ),
                 "sensor.bedroom_humidity": State("sensor.bedroom_humidity", "50"),
                 "light.bedroom": State("light.bedroom", "off"),
             }

--- a/tests/function_executors/test_composite.py
+++ b/tests/function_executors/test_composite.py
@@ -1,16 +1,7 @@
 """Tests for CompositeFunctionExecutor using yaml definitions."""
 
-import sys
-from pathlib import Path
-
-# Add config directory to path for custom_components imports
-config_dir = Path(__file__).parent.parent.parent.parent.parent
-if str(config_dir) not in sys.path:
-    sys.path.insert(0, str(config_dir))
-
-import pytest
-
 from homeassistant.core import State
+import pytest
 
 # Import FunctionExecutors and test helpers
 from custom_components.extended_openai_conversation.helpers import (

--- a/tests/function_executors/test_native.py
+++ b/tests/function_executors/test_native.py
@@ -1,13 +1,6 @@
 """Tests for NativeFunctionExecutor using yaml definitions."""
 
-import sys
-from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
-
-# Add config directory to path for custom_components imports
-config_dir = Path(__file__).parent.parent.parent.parent.parent
-if str(config_dir) not in sys.path:
-    sys.path.insert(0, str(config_dir))
 
 import pytest
 
@@ -215,6 +208,7 @@ class TestNativeGetHistory:
     async def test_get_history(self, hass, exposed_entities, llm_context):
         """Test getting entity history with composite function."""
         from unittest.mock import MagicMock, patch
+
         from custom_components.extended_openai_conversation.helpers import (
             CompositeFunctionExecutor,
         )

--- a/tests/function_executors/test_native.py
+++ b/tests/function_executors/test_native.py
@@ -231,11 +231,14 @@ class TestNativeGetHistory:
 
         executor = CompositeFunctionExecutor()
 
-        with patch(
-            "custom_components.extended_openai_conversation.helpers.recorder.get_instance",
-            return_value=mock_recorder_instance,
-        ), patch(
-            "custom_components.extended_openai_conversation.helpers.recorder.util.session_scope"
+        with (
+            patch(
+                "custom_components.extended_openai_conversation.helpers.recorder.get_instance",
+                return_value=mock_recorder_instance,
+            ),
+            patch(
+                "custom_components.extended_openai_conversation.helpers.recorder.util.session_scope"
+            ),
         ):
             result = await executor.execute(
                 hass, processed_function, arguments, llm_context, exposed_entities

--- a/tests/function_executors/test_rest.py
+++ b/tests/function_executors/test_rest.py
@@ -37,7 +37,7 @@ class TestRestFunctionExecutorYaml:
             mock_rest_data = AsyncMock()
             mock_rest_data.async_update = AsyncMock()
             # Mock weather API response
-            weather_response = '''{
+            weather_response = """{
                 "name": "Seoul",
                 "weather": [{"description": "clear sky"}],
                 "main": {
@@ -46,7 +46,7 @@ class TestRestFunctionExecutorYaml:
                     "humidity": 65
                 },
                 "wind": {"speed": 3.5}
-            }'''
+            }"""
             mock_rest_data.data_without_xml = MagicMock(return_value=weather_response)
             mock_create_rest.return_value = mock_rest_data
 

--- a/tests/function_executors/test_rest.py
+++ b/tests/function_executors/test_rest.py
@@ -1,13 +1,5 @@
 """Tests for RestFunctionExecutor using yaml definitions."""
 
-import sys
-from pathlib import Path
-
-# Add config directory to path for custom_components imports
-config_dir = Path(__file__).parent.parent.parent.parent.parent
-if str(config_dir) not in sys.path:
-    sys.path.insert(0, str(config_dir))
-
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest

--- a/tests/function_executors/test_scrape.py
+++ b/tests/function_executors/test_scrape.py
@@ -46,7 +46,7 @@ class TestScrapeFunctionExecutorYaml:
 
             mock_coordinator = AsyncMock()
             # Mock Hacker News HTML structure
-            html = '''
+            html = """
             <html>
                 <tr class="athing">
                     <td class="title">
@@ -61,7 +61,7 @@ class TestScrapeFunctionExecutorYaml:
                     </td>
                 </tr>
             </html>
-            '''
+            """
             mock_coordinator.data = BeautifulSoup(html, "html.parser")
             mock_coordinator.async_config_entry_first_refresh = AsyncMock()
             mock_coordinator_class.return_value = mock_coordinator

--- a/tests/function_executors/test_scrape.py
+++ b/tests/function_executors/test_scrape.py
@@ -1,13 +1,5 @@
 """Tests for ScrapeFunctionExecutor using yaml definitions."""
 
-import sys
-from pathlib import Path
-
-# Add config directory to path for custom_components imports
-config_dir = Path(__file__).parent.parent.parent.parent.parent
-if str(config_dir) not in sys.path:
-    sys.path.insert(0, str(config_dir))
-
 from unittest.mock import AsyncMock, patch
 
 import pytest

--- a/tests/function_executors/test_script.py
+++ b/tests/function_executors/test_script.py
@@ -1,13 +1,5 @@
 """Tests for ScriptFunctionExecutor using yaml definitions."""
 
-import sys
-from pathlib import Path
-
-# Add config directory to path for custom_components imports
-config_dir = Path(__file__).parent.parent.parent.parent.parent
-if str(config_dir) not in sys.path:
-    sys.path.insert(0, str(config_dir))
-
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest

--- a/tests/function_executors/test_sqlite.py
+++ b/tests/function_executors/test_sqlite.py
@@ -1,13 +1,5 @@
 """Tests for SqliteFunctionExecutor using yaml definitions."""
 
-import sys
-from pathlib import Path
-
-# Add config directory to path for custom_components imports
-config_dir = Path(__file__).parent.parent.parent.parent.parent
-if str(config_dir) not in sys.path:
-    sys.path.insert(0, str(config_dir))
-
 import pytest
 
 # Import FunctionExecutors and test helpers
@@ -33,13 +25,14 @@ class TestSqliteFunctionExecutorYaml:
         import sqlite3
 
         # Add sensor.living_room_temperature to exposed entities for this test
-        exposed_entities = exposed_entities + [
+        exposed_entities = [
+            *exposed_entities,
             {
                 "entity_id": "sensor.living_room_temperature",
                 "name": "Living Room Temperature",
                 "state": "23.5",
                 "aliases": [],
-            }
+            },
         ]
 
         # Update the database schema to match the new query

--- a/tests/function_executors/test_sqlite.py
+++ b/tests/function_executors/test_sqlite.py
@@ -51,6 +51,7 @@ class TestSqliteFunctionExecutorYaml:
 
         # Insert test data with timestamps
         import time
+
         current_time = int(time.time())
         cursor.executemany(
             "INSERT INTO states VALUES (?, ?, ?)",

--- a/tests/function_executors/test_template.py
+++ b/tests/function_executors/test_template.py
@@ -1,16 +1,7 @@
 """Tests for TemplateFunctionExecutor using yaml definitions."""
 
-import sys
-from pathlib import Path
-
-# Add config directory to path for custom_components imports
-config_dir = Path(__file__).parent.parent.parent.parent.parent
-if str(config_dir) not in sys.path:
-    sys.path.insert(0, str(config_dir))
-
-import pytest
-
 from homeassistant.core import State
+import pytest
 
 # Import FunctionExecutors and test helpers
 from custom_components.extended_openai_conversation.helpers import (

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -2,6 +2,7 @@
 
 from pathlib import Path
 from typing import Any
+
 import yaml
 
 


### PR DESCRIPTION
This PR fixes the CI failures caused by linting errors (`ruff`) in the `tests/` directory.

Key changes:
1.  **Centralized `sys.path` configuration**: The code to add the project root to `sys.path` (for importing `custom_components`) was duplicated in every test file, causing "imports not at top of file" (`E402`) errors. This has been moved to `tests/conftest.py`, which is loaded first by `pytest`.
2.  **Linting fixes**: Resolved `F841` (unused variables) and `RUF005` (iterable unpacking) errors.
3.  **Cleanup**: Removed unused imports and sorted imports to comply with `I001`.

---
*PR created automatically by Jules for task [372476013055271180](https://jules.google.com/task/372476013055271180) started by @jekalmin*