### PR TITLE
Sync OpenAI version to 2.21.0 and min HA to 2026.3.0b0

### DIFF
--- a/custom_components/extended_openai_conversation/manifest.json
+++ b/custom_components/extended_openai_conversation/manifest.json
@@ -19,7 +19,7 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/jekalmin/extended_openai_conversation/issues",
   "requirements": [
-    "openai~=2.15.0"
+    "openai~=2.21.0"
   ],
   "version": "3.0.0"
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
   "name": "extended_openai_conversation",
   "render_readme": true,
-  "homeassistant": "2026.2.0b0"
+  "homeassistant": "2026.3.0b0"
 }


### PR DESCRIPTION
Syncs the OpenAI dependency version to 2.21.0 and the minimum Home Assistant version to 2026.3.0b0, aligning with the latest changes in the Home Assistant Core dev branch.

---
*PR created automatically by Jules for task [4338561055262549867](https://jules.google.com/task/4338561055262549867) started by @jekalmin*