### PR TITLE
Sync openai dependency to >=2.21.0 and min HA to 2026.3.0b0

### DIFF
--- a/custom_components/extended_openai_conversation/conversation.py
+++ b/custom_components/extended_openai_conversation/conversation.py
@@ -370,7 +370,11 @@ class ExtendedOpenAIAgentEntity(
             model_lower.startswith(prefix) or f"-{prefix}" in model_lower
             for prefix in ("gpt-4o", "gpt-5", "o1", "o3", "o4")
         )
-        token_kwargs = {"max_completion_tokens": max_tokens} if use_new_token_param else {"max_tokens": max_tokens}
+        token_kwargs = (
+            {"max_completion_tokens": max_tokens}
+            if use_new_token_param
+            else {"max_tokens": max_tokens}
+        )
 
         response = await self.client.chat.completions.create(
             model=model,

--- a/custom_components/extended_openai_conversation/exceptions.py
+++ b/custom_components/extended_openai_conversation/exceptions.py
@@ -1,4 +1,5 @@
 """The exceptions used by Extended OpenAI Conversation."""
+
 from homeassistant.exceptions import HomeAssistantError
 
 

--- a/custom_components/extended_openai_conversation/manifest.json
+++ b/custom_components/extended_openai_conversation/manifest.json
@@ -18,7 +18,7 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/jekalmin/extended_openai_conversation/issues",
   "requirements": [
-    "openai~=2.15.0"
+    "openai>=2.21.0"
   ],
   "version": "2.0.1"
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
   "name": "extended_openai_conversation",
   "render_readme": true,
-  "homeassistant": "2026.2.0b0"
+  "homeassistant": "2026.3.0b0"
 }


### PR DESCRIPTION
Updated manifest.json to require openai>=2.21.0 to match the official component. Updated hacs.json to require homeassistant 2026.3.0b0 based on current dev version.

---
*PR created automatically by Jules for task [204524256066399870](https://jules.google.com/task/204524256066399870) started by @jekalmin*