### PR TITLE
Update OpenAI to v2.21.0 and Min HA to 2026.3.0b0

### DIFF
--- a/custom_components/extended_openai_conversation/manifest.json
+++ b/custom_components/extended_openai_conversation/manifest.json
@@ -18,7 +18,7 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/jekalmin/extended_openai_conversation/issues",
   "requirements": [
-    "openai~=2.15.0"
+    "openai~=2.21.0"
   ],
   "version": "2.0.1"
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
   "name": "extended_openai_conversation",
   "render_readme": true,
-  "homeassistant": "2026.2.0b0"
+  "homeassistant": "2026.3.0b0"
 }


### PR DESCRIPTION
Synchronize dependencies with Home Assistant Core `dev` branch.
- Updated `openai` requirement in `manifest.json` from `~=2.15.0` to `~=2.21.0`.
- Updated minimum Home Assistant version in `hacs.json` from `2026.2.0b0` to `2026.3.0b0`.

---
*PR created automatically by Jules for task [7779317905731177859](https://jules.google.com/task/7779317905731177859) started by @jekalmin*