### PR TITLE
Update OpenAI dependency to ~=2.21.0 and min HA to 2026.3.0b0

### DIFF
--- a/custom_components/extended_openai_conversation/manifest.json
+++ b/custom_components/extended_openai_conversation/manifest.json
@@ -18,7 +18,7 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/jekalmin/extended_openai_conversation/issues",
   "requirements": [
-    "openai~=2.15.0"
+    "openai~=2.21.0"
   ],
   "version": "2.0.2"
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
   "name": "extended_openai_conversation",
   "render_readme": true,
-  "homeassistant": "2026.2.0b0"
+  "homeassistant": "2026.3.0b0"
 }


### PR DESCRIPTION
This PR updates the `openai` dependency and the minimum Home Assistant version to align with the latest changes in the Home Assistant Core `dev` branch.

**Changes:**
- **OpenAI Dependency:** Updated from `~=2.15.0` to `~=2.21.0` in `custom_components/extended_openai_conversation/manifest.json`.
- **Minimum Home Assistant Version:** Updated from `2026.2.0b0` to `2026.3.0b0` in `hacs.json`.

**References (HA Core `dev` branch):**
- OpenAI Manifest: https://github.com/home-assistant/core/blob/dev/homeassistant/components/openai_conversation/manifest.json
- HA Core Version (`pyproject.toml`): https://github.com/home-assistant/core/blob/dev/pyproject.toml


---
*PR created automatically by Jules for task [1364325571469776416](https://jules.google.com/task/1364325571469776416) started by @jekalmin*