### PR TITLE
Bump openai to 2.21.0 and minimum Home Assistant to 2026.3.0b0

### DIFF
--- a/custom_components/extended_openai_conversation/manifest.json
+++ b/custom_components/extended_openai_conversation/manifest.json
@@ -19,7 +19,7 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/jekalmin/extended_openai_conversation/issues",
   "requirements": [
-    "openai~=2.15.0"
+    "openai~=2.21.0"
   ],
   "version": "3.0.0"
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
   "name": "extended_openai_conversation",
   "render_readme": true,
-  "homeassistant": "2026.2.0b0"
+  "homeassistant": "2026.3.0b0"
 }


### PR DESCRIPTION
This PR synchronizes the OpenAI dependency version and the minimum Home Assistant version with the latest `dev` branch of Home Assistant Core.

**Changes:**
- **OpenAI Version:** Updated from `~=2.15.0` to `~=2.21.0` in `custom_components/extended_openai_conversation/manifest.json`.
- **Minimum HA Version:** Updated from `2026.2.0b0` to `2026.3.0b0` in `hacs.json`.

**References:**
- OpenAI Version: [https://raw.githubusercontent.com/home-assistant/core/dev/homeassistant/components/openai_conversation/manifest.json](https://raw.githubusercontent.com/home-assistant/core/dev/homeassistant/components/openai_conversation/manifest.json)
- Home Assistant Version: [https://raw.githubusercontent.com/home-assistant/core/dev/pyproject.toml](https://raw.githubusercontent.com/home-assistant/core/dev/pyproject.toml)

This ensures compatibility with the upcoming Home Assistant release and aligns the `openai` library version to prevent conflicts.

---
*PR created automatically by Jules for task [5124457802479965704](https://jules.google.com/task/5124457802479965704) started by @jekalmin*