### PR TITLE
Update openai to ~=2.21.0 and HA to 2026.3.0b0

### DIFF
--- a/custom_components/extended_openai_conversation/manifest.json
+++ b/custom_components/extended_openai_conversation/manifest.json
@@ -19,7 +19,7 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/jekalmin/extended_openai_conversation/issues",
   "requirements": [
-    "openai~=2.15.0"
+    "openai~=2.21.0"
   ],
   "version": "3.0.0"
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
   "name": "extended_openai_conversation",
   "render_readme": true,
-  "homeassistant": "2026.2.0b0"
+  "homeassistant": "2026.3.0b0"
 }


### PR DESCRIPTION
Update `openai` dependency to `~=2.21.0` and Home Assistant minimum version to `2026.3.0b0` based on Home Assistant Core `dev` branch.

Sources:
- HA Core `pyproject.toml` (version `2026.3.0.dev0` -> `2026.3.0b0`): https://raw.githubusercontent.com/home-assistant/core/dev/pyproject.toml
- HA Core `openai_conversation/manifest.json` (`openai==2.21.0` -> `openai~=2.21.0`): https://raw.githubusercontent.com/home-assistant/core/dev/homeassistant/components/openai_conversation/manifest.json

Verification:
- Linting (Ruff) passed.
- Mypy check passed (unrelated existing errors ignored).
- Local tests run but failed due to environment mismatch (missing `ConfigSubentry` in local `homeassistant` package), as the codebase targets a future dev version of HA. Config changes verified manually against remote sources.

---
*PR created automatically by Jules for task [11197113423770182548](https://jules.google.com/task/11197113423770182548) started by @jekalmin*