### PR TITLE
Update openai to ~=2.21.0 and HA min version to 2026.3.0b0

### DIFF
--- a/custom_components/extended_openai_conversation/manifest.json
+++ b/custom_components/extended_openai_conversation/manifest.json
@@ -19,7 +19,7 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/jekalmin/extended_openai_conversation/issues",
   "requirements": [
-    "openai~=2.15.0"
+    "openai~=2.21.0"
   ],
   "version": "3.0.0"
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
   "name": "extended_openai_conversation",
   "render_readme": true,
-  "homeassistant": "2026.2.0b0"
+  "homeassistant": "2026.3.0b0"
 }


### PR DESCRIPTION
Update dependencies based on Home Assistant Core `dev` branch.

- Update `openai` requirement in `manifest.json` to `~=2.21.0` (matching official component).
- Update `homeassistant` minimum version in `hacs.json` to `2026.3.0b0` (derived from `2026.3.0.dev0`).

Sources verified:
- https://raw.githubusercontent.com/home-assistant/core/dev/homeassistant/components/openai_conversation/manifest.json
- https://raw.githubusercontent.com/home-assistant/core/dev/pyproject.toml

---
*PR created automatically by Jules for task [11510377787626530816](https://jules.google.com/task/11510377787626530816) started by @jekalmin*