### PR TITLE
Update dependencies: OpenAI >=2.21.0 and HA 2026.4.0b0

### DIFF
--- a/custom_components/extended_openai_conversation/manifest.json
+++ b/custom_components/extended_openai_conversation/manifest.json
@@ -19,7 +19,7 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/jekalmin/extended_openai_conversation/issues",
   "requirements": [
-    "openai~=2.15.0"
+    "openai>=2.21.0"
   ],
   "version": "3.0.0"
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
   "name": "extended_openai_conversation",
   "render_readme": true,
-  "homeassistant": "2026.2.0b0"
+  "homeassistant": "2026.4.0b0"
 }


### PR DESCRIPTION
Updates `openai` dependency and minimum Home Assistant version based on the latest Home Assistant Core `dev` branch.

**Old Versions:**
- `openai`: `~=2.15.0`
- `homeassistant`: `2026.2.0b0`

**New Versions:**
- `openai`: `>=2.21.0`
- `homeassistant`: `2026.4.0b0`

**Verification Sources:**
- **Home Assistant Version:** [pyproject.toml (dev)](https://raw.githubusercontent.com/home-assistant/core/dev/pyproject.toml) -> `2026.4.0.dev0` -> Target `2026.4.0b0`
- **OpenAI Requirement:** [manifest.json (dev)](https://raw.githubusercontent.com/home-assistant/core/dev/homeassistant/components/openai_conversation/manifest.json) -> `openai==2.21.0`

**Note:**
Local environment tests (mypy/pytest) failed due to the unavailability of HA `2026.4.0b0` (or compatible dev build) on PyPI, leading to missing core features like `ConfigSubentry`. The changes are configuration updates verified against the remote `dev` branch.

---
*PR created automatically by Jules for task [6233293252423120586](https://jules.google.com/task/6233293252423120586) started by @jekalmin*