### PR TITLE
Update dependencies: Home Assistant to 2026.4.0b0

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
   "name": "extended_openai_conversation",
   "render_readme": true,
-  "homeassistant": "2026.3.0b0"
+  "homeassistant": "2026.4.0b0"
 }


### PR DESCRIPTION
Updates the `extended_openai_conversation` component dependencies based on the Home Assistant Core `dev` branch.

**Changes:**
- `hacs.json`: Updated minimum Home Assistant version from `2026.3.0b0` to `2026.4.0b0`.
- `manifest.json`: Verified `openai` dependency `~=2.21.0` matches upstream `==2.21.0` (No change needed).

**Sources:**
- Home Assistant Version: [pyproject.toml](https://raw.githubusercontent.com/home-assistant/core/dev/pyproject.toml) (2026.4.0.dev0 -> 2026.4.0b0)
- OpenAI Dependency: [manifest.json](https://raw.githubusercontent.com/home-assistant/core/dev/homeassistant/components/openai_conversation/manifest.json) (openai==2.21.0)

**Verification:**
- Verified `hacs.json` update.
- Verified `manifest.json` compatibility.
- Environment setup with `openai==2.21.0` and `homeassistant` (latest available).
- Linting/Type Checking run (failures unrelated to change ignored as per constraints).

---
*PR created automatically by Jules for task [6057473893340100673](https://jules.google.com/task/6057473893340100673) started by @jekalmin*