### PR TITLE
fix: include unit_of_measurement in get_statistics response

### DIFF
--- a/custom_components/extended_openai_conversation/functions/native.py
+++ b/custom_components/extended_openai_conversation/functions/native.py
@@ -286,14 +286,16 @@ class NativeFunction(Function):
 
         # Inject unit_of_measurement into each entry so the LLM knows the
         # actual unit (Wh, kWh, etc.) instead of assuming kWh by default.
+        result: dict[str, Any] = {}
         for statistic_id, entries in statistics.items():
-            unit = None
+            unit: str | None = None
             if statistic_id in metadata:
-                unit = metadata[statistic_id][1].unit_of_measurement
-            for entry in entries:
-                entry["unit_of_measurement"] = unit
+                unit = metadata[statistic_id][1]["unit_of_measurement"]
+            result[statistic_id] = [
+                {**entry, "unit_of_measurement": unit} for entry in entries
+            ]
 
-        return statistics
+        return result
 
     def as_utc(
         self, value: str | None, default_value: Any, parse_error_message: str

--- a/custom_components/extended_openai_conversation/functions/native.py
+++ b/custom_components/extended_openai_conversation/functions/native.py
@@ -262,7 +262,9 @@ class NativeFunction(Function):
         start_time = dt_util.as_utc(start_time_parsed)
         end_time = dt_util.as_utc(end_time_parsed)
 
-        return await recorder.get_instance(hass).async_add_executor_job(
+        instance = recorder.get_instance(hass)
+
+        statistics = await instance.async_add_executor_job(
             recorder.statistics.statistics_during_period,
             hass,
             start_time,
@@ -272,6 +274,23 @@ class NativeFunction(Function):
             arguments.get("units"),
             arguments.get("types", {"change"}),
         )
+
+        metadata = await instance.async_add_executor_job(
+            recorder.statistics.get_metadata,
+            hass,
+            statistic_ids,
+        )
+
+        # Inject unit_of_measurement into each entry so the LLM knows the
+        # actual unit (Wh, kWh, etc.) instead of assuming kWh by default.
+        for statistic_id, entries in statistics.items():
+            unit = None
+            if statistic_id in metadata:
+                unit = metadata[statistic_id][1].unit_of_measurement
+            for entry in entries:
+                entry["unit_of_measurement"] = unit
+
+        return statistics
 
     def as_utc(
         self, value: str | None, default_value: Any, parse_error_message: str

--- a/custom_components/extended_openai_conversation/functions/native.py
+++ b/custom_components/extended_openai_conversation/functions/native.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import timedelta
+from functools import partial
 import logging
 import os
 import time
@@ -276,9 +277,11 @@ class NativeFunction(Function):
         )
 
         metadata = await instance.async_add_executor_job(
-            recorder.statistics.get_metadata,
-            hass,
-            statistic_ids,
+            partial(
+                recorder.statistics.get_metadata,
+                hass,
+                statistic_ids=set(statistic_ids),
+            )
         )
 
         # Inject unit_of_measurement into each entry so the LLM knows the

--- a/tests/functions/test_native.py
+++ b/tests/functions/test_native.py
@@ -271,9 +271,15 @@ class TestNativeGetStatistics:
             "period": "day",
         }
 
+        mock_metadata = MagicMock()
+        mock_metadata.unit_of_measurement = "°C"
+
         mock_recorder_instance = MagicMock()
         mock_recorder_instance.async_add_executor_job = AsyncMock(
-            return_value={"sensor.temperature": []}
+            side_effect=[
+                {"sensor.temperature": [{"start": "2024-01-01", "change": 5.0}]},
+                {"sensor.temperature": (None, mock_metadata)},
+            ]
         )
 
         with patch(
@@ -285,6 +291,7 @@ class TestNativeGetStatistics:
             )
 
         assert isinstance(result, dict)
+        assert result["sensor.temperature"][0]["unit_of_measurement"] == "°C"
 
     async def test_get_statistics_with_options(
         self, hass, function, exposed_entities, llm_context
@@ -307,7 +314,10 @@ class TestNativeGetStatistics:
 
         mock_recorder_instance = MagicMock()
         mock_recorder_instance.async_add_executor_job = AsyncMock(
-            return_value={"sensor.temperature": [], "sensor.humidity": []}
+            side_effect=[
+                {"sensor.temperature": [], "sensor.humidity": []},
+                {},
+            ]
         )
 
         with patch(
@@ -319,6 +329,89 @@ class TestNativeGetStatistics:
             )
 
         assert isinstance(result, dict)
+
+    async def test_get_statistics_unit_of_measurement_injected(
+        self, hass, function, exposed_entities, llm_context
+    ):
+        """Test that unit_of_measurement from metadata is injected into each entry."""
+        from unittest.mock import MagicMock, patch
+
+        function_tool = prepare_function_tool_from_yaml(
+            "native_get_statistics_example.yaml", index=1
+        )
+        function_config = function_tool["function"]
+        function = get_function(function_config["type"])
+
+        arguments = {
+            "statistic_ids": ["sensor.energy_meter"],
+            "start_time": "2024-01-01T00:00:00Z",
+            "end_time": "2024-01-02T00:00:00Z",
+            "period": "day",
+        }
+
+        mock_metadata = MagicMock()
+        mock_metadata.unit_of_measurement = "Wh"
+
+        mock_recorder_instance = MagicMock()
+        mock_recorder_instance.async_add_executor_job = AsyncMock(
+            side_effect=[
+                {
+                    "sensor.energy_meter": [
+                        {"start": "2024-01-01", "change": 1500.0},
+                        {"start": "2024-01-02", "change": 2000.0},
+                    ]
+                },
+                {"sensor.energy_meter": (None, mock_metadata)},
+            ]
+        )
+
+        with patch(
+            "custom_components.extended_openai_conversation.functions.native.recorder.get_instance",
+            return_value=mock_recorder_instance,
+        ):
+            result = await function.execute(
+                hass, function_config, arguments, llm_context, exposed_entities
+            )
+
+        entries = result["sensor.energy_meter"]
+        assert all(entry["unit_of_measurement"] == "Wh" for entry in entries)
+
+    async def test_get_statistics_missing_metadata(
+        self, hass, function, exposed_entities, llm_context
+    ):
+        """Test that unit_of_measurement is None when metadata is unavailable."""
+        from unittest.mock import MagicMock, patch
+
+        function_tool = prepare_function_tool_from_yaml(
+            "native_get_statistics_example.yaml", index=1
+        )
+        function_config = function_tool["function"]
+        function = get_function(function_config["type"])
+
+        arguments = {
+            "statistic_ids": ["sensor.unknown"],
+            "start_time": "2024-01-01T00:00:00Z",
+            "end_time": "2024-01-02T00:00:00Z",
+            "period": "day",
+        }
+
+        mock_recorder_instance = MagicMock()
+        mock_recorder_instance.async_add_executor_job = AsyncMock(
+            side_effect=[
+                {"sensor.unknown": [{"start": "2024-01-01", "change": 42.0}]},
+                {},  # no metadata for this id
+            ]
+        )
+
+        with patch(
+            "custom_components.extended_openai_conversation.functions.native.recorder.get_instance",
+            return_value=mock_recorder_instance,
+        ):
+            result = await function.execute(
+                hass, function_config, arguments, llm_context, exposed_entities
+            )
+
+        assert result["sensor.unknown"][0]["unit_of_measurement"] is None
 
     async def test_get_statistics_invalid_datetime(
         self, hass, function, exposed_entities, llm_context

--- a/tests/functions/test_native.py
+++ b/tests/functions/test_native.py
@@ -271,14 +271,11 @@ class TestNativeGetStatistics:
             "period": "day",
         }
 
-        mock_metadata = MagicMock()
-        mock_metadata.unit_of_measurement = "°C"
-
         mock_recorder_instance = MagicMock()
         mock_recorder_instance.async_add_executor_job = AsyncMock(
             side_effect=[
                 {"sensor.temperature": [{"start": "2024-01-01", "change": 5.0}]},
-                {"sensor.temperature": (None, mock_metadata)},
+                {"sensor.temperature": (1, {"unit_of_measurement": "°C"})},
             ]
         )
 
@@ -349,9 +346,6 @@ class TestNativeGetStatistics:
             "period": "day",
         }
 
-        mock_metadata = MagicMock()
-        mock_metadata.unit_of_measurement = "Wh"
-
         mock_recorder_instance = MagicMock()
         mock_recorder_instance.async_add_executor_job = AsyncMock(
             side_effect=[
@@ -361,7 +355,7 @@ class TestNativeGetStatistics:
                         {"start": "2024-01-02", "change": 2000.0},
                     ]
                 },
-                {"sensor.energy_meter": (None, mock_metadata)},
+                {"sensor.energy_meter": (1, {"unit_of_measurement": "Wh"})},
             ]
         )
 


### PR DESCRIPTION
## Problem

`get_statistics()` returns raw statistic values without unit information, causing the LLM to always assume kWh even when a device reports in Wh.

Fixes #431

## Solution

Call `recorder.statistics.get_metadata()` alongside `statistics_during_period()` and inject `unit_of_measurement` into each returned entry so the LLM can read the actual unit directly from the data.

**Before:**
```json
{"sensor.energy_meter": [{"start": "2024-01-01", "change": 1500.0}]}
```

**After:**
```json
{"sensor.energy_meter": [{"start": "2024-01-01", "change": 1500.0, "unit_of_measurement": "Wh"}]}
```

## Changes

- `functions/native.py`: fetch metadata and inject `unit_of_measurement` per entry
- `tests/functions/test_native.py`: update existing mocks + add 2 new tests (`test_get_statistics_unit_of_measurement_injected`, `test_get_statistics_missing_metadata`)