### PR TITLE
Update search_plex function

### DIFF
--- a/examples/function/plex/README.md
+++ b/examples/function/plex/README.md
@@ -17,17 +17,7 @@
   function:
     type: rest
     resource_template: "https://YOUR.PLEX.SERVER.TLD/search?query={{query}}&X-Plex-Token=YOURPLEXTOKEN"
-    value_template: >-
-      ```csv
-      title,year,director,type,key
-      {% for metadata in value_json["MediaContainer"]["Metadata"] %}
-        {{ metadata["title"]|replace(",", " ") }},
-        {{ metadata["year"] }},
-        {{ metadata["Director"][0]["tag"] if metadata["Director"] else "N/A" }},
-        {{ metadata["type"] }},
-        {{ metadata["key"] }}
-      {% endfor -%}
-      ```
+    value_template: "{{ value_json }}"
 ```
 
 ### play_plex_media_in_apple_tv


### PR DESCRIPTION
## Problem
Plex search spec returns empty or unstructured results 

## Solution
- Fixed value_template parsing

Before: empty or broken results
After: structured JSON output with all movies returned correctly


## Example 

The current value_template doesn't return any result 

With **value_template: "{{ value_json }}"**, "Search in Plex Terminator" returns :
 
> Terminator (1984)
> Note : 10.0
> 
> Terminator 2: Le Jugement Dernier (1991)
> Note : 9.1
> 
> Terminator 3 : Le Soulèvement des Machines (2003)
> Note : 7.0

<img width="604" height="430" alt="image" src="https://github.com/user-attachments/assets/93ab880b-5d14-4487-ade4-a363176b716c" />


I hope this has been helpful. Thank you.
