### PR TITLE
Add extra_body passthrough for OpenAI-compatible backends

### DIFF
--- a/custom_components/extended_openai_conversation/config_flow.py
+++ b/custom_components/extended_openai_conversation/config_flow.py
@@ -41,6 +41,7 @@ from .const import (
     CONF_CHAT_MODEL,
     CONF_CONTEXT_THRESHOLD,
     CONF_CONTEXT_TRUNCATE_STRATEGY,
+    CONF_EXTRA_BODY,
     CONF_FUNCTION_TOOLS,
     CONF_MAX_FUNCTION_CALLS_PER_CONVERSATION,
     CONF_MAX_TOKENS,
@@ -64,6 +65,7 @@ from .const import (
     DEFAULT_CONTEXT_THRESHOLD,
     DEFAULT_CONTEXT_TRUNCATE_STRATEGY,
     DEFAULT_CONVERSATION_NAME,
+    DEFAULT_EXTRA_BODY,
     DEFAULT_MAX_FUNCTION_CALLS_PER_CONVERSATION,
     DEFAULT_MAX_TOKENS,
     DEFAULT_NAME,
@@ -374,6 +376,16 @@ class ExtendedOpenAISubentryFlowHandler(ConfigSubentryFlow):
                 )
             )
 
+        # Add extra_body — passthrough for OpenAI-compatible backends
+        # (ollama, llama.cpp, vLLM, LM Studio). Accepts a Jinja-templatable
+        # JSON string; empty disables.
+        schema[
+            vol.Optional(
+                CONF_EXTRA_BODY,
+                default=DEFAULT_EXTRA_BODY,
+            )
+        ] = TemplateSelector()
+
         # Add shorten_tool_call_id option (for Mistral AI compatibility)
         schema[
             vol.Optional(
@@ -640,6 +652,16 @@ class ExtendedOpenAIAITaskSubentryFlowHandler(ConfigSubentryFlow):
                     mode=SelectSelectorMode.DROPDOWN,
                 )
             )
+
+        # Add extra_body — passthrough for OpenAI-compatible backends
+        # (ollama, llama.cpp, vLLM, LM Studio). Accepts a Jinja-templatable
+        # JSON string; empty disables.
+        schema[
+            vol.Optional(
+                CONF_EXTRA_BODY,
+                default=DEFAULT_EXTRA_BODY,
+            )
+        ] = TemplateSelector()
 
         # Add shorten_tool_call_id option (for Mistral AI compatibility)
         schema[

--- a/custom_components/extended_openai_conversation/const.py
+++ b/custom_components/extended_openai_conversation/const.py
@@ -242,7 +242,9 @@ SERVICE_TIER_OPTIONS = ["auto", "default", "flex", "priority"]
 
 # Reasoning Effort options (for o1, o3, o4, gpt-5 models)
 CONF_REASONING_EFFORT = "reasoning_effort"
+CONF_EXTRA_BODY = "extra_body"
 DEFAULT_REASONING_EFFORT = "low"
+DEFAULT_EXTRA_BODY = ""
 REASONING_EFFORT_OPTIONS = ["low", "medium", "high"]
 
 SERVICE_QUERY_IMAGE = "query_image"

--- a/custom_components/extended_openai_conversation/entity.py
+++ b/custom_components/extended_openai_conversation/entity.py
@@ -20,7 +20,8 @@ from voluptuous_openapi import convert
 
 from homeassistant.components import conversation
 from homeassistant.config_entries import ConfigSubentry
-from homeassistant.helpers import device_registry as dr, llm
+from homeassistant.exceptions import TemplateError
+from homeassistant.helpers import device_registry as dr, llm, template
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import slugify
 
@@ -28,6 +29,7 @@ from .const import (
     CONF_CHAT_MODEL,
     CONF_CONTEXT_THRESHOLD,
     CONF_CONTEXT_TRUNCATE_STRATEGY,
+    CONF_EXTRA_BODY,
     CONF_MAX_FUNCTION_CALLS_PER_CONVERSATION,
     CONF_MAX_TOKENS,
     CONF_REASONING_EFFORT,
@@ -38,6 +40,7 @@ from .const import (
     DEFAULT_CHAT_MODEL,
     DEFAULT_CONTEXT_THRESHOLD,
     DEFAULT_CONTEXT_TRUNCATE_STRATEGY,
+    DEFAULT_EXTRA_BODY,
     DEFAULT_MAX_FUNCTION_CALLS_PER_CONVERSATION,
     DEFAULT_MAX_TOKENS,
     DEFAULT_REASONING_EFFORT,
@@ -253,6 +256,23 @@ class ExtendedOpenAIBaseLLMEntity(Entity):
             api_kwargs["service_tier"] = options.get(
                 CONF_SERVICE_TIER, DEFAULT_SERVICE_TIER
             )
+
+        # Add extra_body if configured — passthrough for OpenAI-compatible
+        # backends that accept extra request-body fields (ollama, llama.cpp,
+        # vLLM, LM Studio, etc.). E.g. {"chat_template_kwargs":
+        # {"enable_thinking": false}} to disable Qwen3 reasoning, or
+        # {"cache_prompt": true} for llama.cpp prompt caching. Value is a
+        # Jinja-templatable JSON string; empty string disables.
+        extra_body_raw = options.get(CONF_EXTRA_BODY, DEFAULT_EXTRA_BODY) or ""
+        if extra_body_raw.strip():
+            try:
+                rendered = template.Template(extra_body_raw, self.hass).async_render(
+                    parse_result=False
+                )
+                if rendered.strip():
+                    api_kwargs["extra_body"] = json.loads(rendered)
+            except (TemplateError, json.JSONDecodeError) as err:
+                _LOGGER.warning("Invalid extra_body for %s, ignoring: %s", model, err)
 
         # Add structured output format if provided
         if structure is not None:

--- a/custom_components/extended_openai_conversation/strings.json
+++ b/custom_components/extended_openai_conversation/strings.json
@@ -48,6 +48,7 @@
             "temperature": "Temperature",
             "top_p": "Top P",
             "reasoning_effort": "Reasoning effort",
+            "extra_body": "Extra body (JSON for OpenAI-compatible backends)",
             "service_tier": "Service tier",
             "shorten_tool_call_id": "Shorten tool call IDs"
           },
@@ -78,6 +79,7 @@
             "temperature": "Temperature",
             "top_p": "Top P",
             "reasoning_effort": "Reasoning effort",
+            "extra_body": "Extra body (JSON for OpenAI-compatible backends)",
             "service_tier": "Service tier",
             "shorten_tool_call_id": "Shorten tool call IDs"
           },

--- a/custom_components/extended_openai_conversation/translations/en.json
+++ b/custom_components/extended_openai_conversation/translations/en.json
@@ -48,6 +48,7 @@
                         "temperature": "Temperature",
                         "top_p": "Top P",
                         "reasoning_effort": "Reasoning effort",
+                        "extra_body": "Extra body (JSON for OpenAI-compatible backends)",
                         "service_tier": "Service tier",
                         "shorten_tool_call_id": "Shorten tool call IDs"
                     },
@@ -78,6 +79,7 @@
                         "temperature": "Temperature",
                         "top_p": "Top P",
                         "reasoning_effort": "Reasoning effort",
+                        "extra_body": "Extra body (JSON for OpenAI-compatible backends)",
                         "service_tier": "Service tier",
                         "shorten_tool_call_id": "Shorten tool call IDs"
                     },


### PR DESCRIPTION
## Summary

Adds an `extra_body` option that's forwarded to `chat.completions.create()`. The OpenAI Python SDK merges `extra_body` into the JSON request body before sending — letting users pass provider-specific fields that aren't in the standard OpenAI schema.

This is for OpenAI-compatible backends behind the integration:

- **ollama / llama.cpp / vLLM / LM Studio** accept `chat_template_kwargs` (Qwen3 thinking toggle), `cache_prompt`, `mirostat_*`, `min_p`, etc.
- **Anthropic-compatible proxies** accept `thinking.budget_tokens`, `system` array shapes, etc.
- **Forks of OpenAI's API** that add their own fields.

Without this, the only ways to use those backend-specific features are (a) modifying the model server's defaults or (b) running a body-rewriting reverse proxy. With this PR users can configure them per-conversation-entity directly in HA's UI.

## Motivating example

Qwen3 models (qwen3-32b, qwen3.6-35b-a3b, etc.) running on llama.cpp default to thinking mode, which adds 3-5+ seconds per turn before generating the user-visible answer. Disabling thinking via the server-side default isn't always desirable (other callers may want reasoning). With this PR, the voice-pipeline conversation entity can set:

```json
{"chat_template_kwargs": {"enable_thinking": false}}
```

and skip reasoning for its turns only.

In local testing this brought my Qwen3.6-35B-A3B per-turn latency from ~5.6s to ~0.3s, with no other code changes.

## What changed

| File | Change |
|---|---|
| `const.py` | New `CONF_EXTRA_BODY` + `DEFAULT_EXTRA_BODY = ""` |
| `entity.py` | Parse `options[extra_body]` as a Jinja-templatable JSON string, inject as `api_kwargs["extra_body"]` if non-empty. Invalid template/JSON → warning log, call proceeds without it (graceful) |
| `config_flow.py` | Surface as a `TemplateSelector` field in both the `conversation` and `ai_task_data` subentry option flows, alongside the existing `reasoning_effort` / `service_tier` toggles |
| `strings.json` + `translations/en.json` | UI label |

53 insertions, 1 deletion. No behavioral change for users who leave the field empty (the default).

## Why a templated JSON field rather than a dedicated `disable_thinking` boolean

Keeps the integration provider-agnostic. Adding one toggle per vendor-specific field doesn't scale: today qwen wants `chat_template_kwargs`, tomorrow it'll be reasoning-effort variants for new models, llama.cpp's `min_p`, `top_k`, `repeat_penalty`, etc. A single `extra_body` text field is one knob that handles all of them.

The OpenAI SDK has had `extra_body=` support for years specifically as the escape hatch for this use case — see [`openai-python`'s `_base_client.py`](https://github.com/openai/openai-python/blob/main/src/openai/_base_client.py) for the merge logic.

## Testing

Manual: ran the patched integration against a `llama-server`-hosted Qwen3.6-35B-A3B endpoint, set `extra_body` to `{"chat_template_kwargs": {"enable_thinking": false}}` via the conversation subentry's options page, and confirmed:

- Reasoning tokens dropped to 0 in the OpenAI response payload
- `_LOGGER.info("Prompt for %s: ...")` log line shows the field is honored
- Per-turn latency dropped from 5.6s → 0.3s on the test prompt
- Empty string in the field disables (no `extra_body` arg sent, byte-identical request to before this PR)
- Invalid JSON in the field logs `_LOGGER.warning(...)` and falls back to no-extra-body (call still succeeds)

`ruff check` + `ruff format` clean on touched files.

## Out of scope (potential follow-up if you want)

`services.py`'s `query_image` service also has a `chat.completions.create` call that would benefit from the same passthrough. Left out of this PR because (a) it's invoked per-call with its own data payload and the right place to put `extra_body` there is a separate design question (per-call arg vs entry option), and (b) keeping this PR focused on the conversation/ai_task entity path.

Happy to add `services.py` coverage as a follow-up commit or separate PR if you'd prefer that scope.