### PR TITLE
fix: resolve mypy error for Template with nullable hass argument

### DIFF
--- a/custom_components/extended_openai_conversation/helpers.py
+++ b/custom_components/extended_openai_conversation/helpers.py
@@ -107,8 +107,10 @@ def _convert_to_template(
 ) -> None:
     if isinstance(settings, dict):
         for key, value in settings.items():
-            if isinstance(value, str) and (
-                key in template_keys or set(parents).intersection(template_keys)
+            if (
+                isinstance(value, str)
+                and hass is not None
+                and (key in template_keys or set(parents).intersection(template_keys))
             ):
                 settings[key] = Template(value, hass)
             if isinstance(value, dict):


### PR DESCRIPTION
## Summary

- `helpers.py:113` called `Template(value, hass)` where `hass` is typed as `HomeAssistant | None`, but the current HA version requires `hass` to be `HomeAssistant` (non-optional)
- Fixed by adding `hass is not None` guard to the condition, so template conversion is skipped when `hass` is unavailable

## Changes

`custom_components/extended_openai_conversation/helpers.py`
```python
# before
if isinstance(value, str) and (
    key in template_keys or set(parents).intersection(template_keys)
):
    settings[key] = Template(value, hass)

# after
if isinstance(value, str) and hass is not None and (
    key in template_keys or set(parents).intersection(template_keys)
):
    settings[key] = Template(value, hass)
```

## Related

- CI `Type Check` job has been failing daily on `develop` branch since 2026-05-03
- Error: `Argument 2 to "Template" has incompatible type "HomeAssistant | None"; expected "HomeAssistant" [arg-type]`