### PR TITLE
feat: add opt-in "Follow redirects" connection flag

### DIFF
--- a/custom_components/extended_openai_conversation/__init__.py
+++ b/custom_components/extended_openai_conversation/__init__.py
@@ -18,9 +18,11 @@ from .const import (
     CONF_API_PROVIDER,
     CONF_API_VERSION,
     CONF_BASE_URL,
+    CONF_FOLLOW_REDIRECTS,
     CONF_ORGANIZATION,
     CONF_SKIP_AUTHENTICATION,
     DEFAULT_API_PROVIDER,
+    DEFAULT_FOLLOW_REDIRECTS,
     DEFAULT_SKIP_AUTHENTICATION,
     DOMAIN,
 )
@@ -59,6 +61,9 @@ async def async_setup_entry(
                 CONF_SKIP_AUTHENTICATION, DEFAULT_SKIP_AUTHENTICATION
             ),
             api_provider=entry.data.get(CONF_API_PROVIDER, DEFAULT_API_PROVIDER),
+            follow_redirects=entry.data.get(
+                CONF_FOLLOW_REDIRECTS, DEFAULT_FOLLOW_REDIRECTS
+            ),
         )
     except AuthenticationError as err:
         _LOGGER.error("Invalid API key: %s", err)

--- a/custom_components/extended_openai_conversation/config_flow.py
+++ b/custom_components/extended_openai_conversation/config_flow.py
@@ -41,6 +41,7 @@ from .const import (
     CONF_CHAT_MODEL,
     CONF_CONTEXT_THRESHOLD,
     CONF_CONTEXT_TRUNCATE_STRATEGY,
+    CONF_FOLLOW_REDIRECTS,
     CONF_FUNCTION_TOOLS,
     CONF_MAX_FUNCTION_CALLS_PER_CONVERSATION,
     CONF_MAX_TOKENS,
@@ -64,6 +65,7 @@ from .const import (
     DEFAULT_CONTEXT_THRESHOLD,
     DEFAULT_CONTEXT_TRUNCATE_STRATEGY,
     DEFAULT_CONVERSATION_NAME,
+    DEFAULT_FOLLOW_REDIRECTS,
     DEFAULT_MAX_FUNCTION_CALLS_PER_CONVERSATION,
     DEFAULT_MAX_TOKENS,
     DEFAULT_NAME,
@@ -93,6 +95,7 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
         vol.Optional(
             CONF_SKIP_AUTHENTICATION, default=DEFAULT_SKIP_AUTHENTICATION
         ): bool,
+        vol.Optional(CONF_FOLLOW_REDIRECTS, default=DEFAULT_FOLLOW_REDIRECTS): bool,
         vol.Optional(CONF_API_PROVIDER, default=DEFAULT_API_PROVIDER): SelectSelector(
             SelectSelectorConfig(
                 options=[
@@ -138,6 +141,7 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> None:
     api_version = data.get(CONF_API_VERSION)
     organization = data.get(CONF_ORGANIZATION)
     skip_authentication = data.get(CONF_SKIP_AUTHENTICATION, False)
+    follow_redirects = data.get(CONF_FOLLOW_REDIRECTS, DEFAULT_FOLLOW_REDIRECTS)
     api_provider = data.get(CONF_API_PROVIDER)
 
     if base_url == DEFAULT_CONF_BASE_URL:
@@ -156,6 +160,7 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> None:
         organization=organization,
         api_provider=api_provider,
         skip_authentication=skip_authentication,
+        follow_redirects=follow_redirects,
     )
 
 

--- a/custom_components/extended_openai_conversation/const.py
+++ b/custom_components/extended_openai_conversation/const.py
@@ -11,6 +11,8 @@ DEFAULT_CONF_BASE_URL = "https://api.openai.com/v1"
 CONF_API_VERSION = "api_version"
 CONF_SKIP_AUTHENTICATION = "skip_authentication"
 DEFAULT_SKIP_AUTHENTICATION = False
+CONF_FOLLOW_REDIRECTS = "follow_redirects"
+DEFAULT_FOLLOW_REDIRECTS = False
 CONF_API_PROVIDER = "api_provider"
 API_PROVIDERS = [
     {"key": "openai", "label": "OpenAI"},

--- a/custom_components/extended_openai_conversation/helpers.py
+++ b/custom_components/extended_openai_conversation/helpers.py
@@ -13,10 +13,14 @@ from homeassistant.components import conversation
 from homeassistant.components.homeassistant.exposed_entities import async_should_expose
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
-from homeassistant.helpers.httpx_client import get_async_client
+from homeassistant.helpers.httpx_client import (
+    create_async_httpx_client,
+    get_async_client,
+)
 from homeassistant.helpers.template import Template
 
 from .const import (
+    DEFAULT_FOLLOW_REDIRECTS,
     DEFAULT_MODEL_CONFIG,
     DEFAULT_TOKEN_PARAM,
     MODEL_CONFIG_PATTERNS,
@@ -135,8 +139,15 @@ async def get_authenticated_client(
     organization: str | None,
     api_provider: str | None,
     skip_authentication: bool = False,
+    follow_redirects: bool = DEFAULT_FOLLOW_REDIRECTS,
 ) -> AsyncClient:
     """Validate OpenAI authentication."""
+
+    http_client = (
+        create_async_httpx_client(hass, follow_redirects=True)
+        if follow_redirects
+        else get_async_client(hass)
+    )
 
     client: AsyncClient
     if base_url and (is_azure_url(base_url) or api_provider == "azure"):
@@ -145,14 +156,14 @@ async def get_authenticated_client(
             azure_endpoint=base_url,
             api_version=api_version,
             organization=organization,
-            http_client=get_async_client(hass),
+            http_client=http_client,
         )
     else:
         client = AsyncOpenAI(
             api_key=api_key,
             base_url=base_url,
             organization=organization,
-            http_client=get_async_client(hass),
+            http_client=http_client,
         )
 
     if skip_authentication:

--- a/custom_components/extended_openai_conversation/services.py
+++ b/custom_components/extended_openai_conversation/services.py
@@ -25,9 +25,11 @@ from .const import (
     CONF_API_PROVIDER,
     CONF_API_VERSION,
     CONF_BASE_URL,
+    CONF_FOLLOW_REDIRECTS,
     CONF_ORGANIZATION,
     CONF_SKIP_AUTHENTICATION,
     DEFAULT_CONF_BASE_URL,
+    DEFAULT_FOLLOW_REDIRECTS,
     DOMAIN,
     GITHUB_REPO_NAME,
     GITHUB_REPO_OWNER,
@@ -65,6 +67,7 @@ CHANGE_CONFIG_SCHEMA = vol.Schema(
         vol.Optional(CONF_API_VERSION): cv.string,
         vol.Optional(CONF_ORGANIZATION): cv.string,
         vol.Optional(CONF_SKIP_AUTHENTICATION): cv.boolean,
+        vol.Optional(CONF_FOLLOW_REDIRECTS): cv.boolean,
         vol.Optional(CONF_API_PROVIDER): cv.string,
     }
 )
@@ -135,6 +138,7 @@ async def async_setup_services(hass: HomeAssistant, config: ConfigType) -> None:
             CONF_API_VERSION,
             CONF_ORGANIZATION,
             CONF_SKIP_AUTHENTICATION,
+            CONF_FOLLOW_REDIRECTS,
             CONF_API_PROVIDER,
         ):
             if key in call.data:
@@ -165,6 +169,9 @@ async def async_setup_services(hass: HomeAssistant, config: ConfigType) -> None:
             organization=new_data.get(CONF_ORGANIZATION),
             skip_authentication=new_data.get(CONF_SKIP_AUTHENTICATION, False),
             api_provider=new_data.get(CONF_API_PROVIDER),
+            follow_redirects=new_data.get(
+                CONF_FOLLOW_REDIRECTS, DEFAULT_FOLLOW_REDIRECTS
+            ),
         )
 
         hass.config_entries.async_update_entry(entry, data=new_data)

--- a/custom_components/extended_openai_conversation/services.yaml
+++ b/custom_components/extended_openai_conversation/services.yaml
@@ -52,6 +52,9 @@ change_config:
     skip_authentication:
       selector:
         boolean:
+    follow_redirects:
+      selector:
+        boolean:
     api_provider:
       example: openai
       selector:

--- a/custom_components/extended_openai_conversation/strings.json
+++ b/custom_components/extended_openai_conversation/strings.json
@@ -9,6 +9,7 @@
           "api_version": "[%key:common::config_flow::data::api_version%]",
           "organization": "[%key:common::config_flow::data::organization%]",
           "skip_authentication": "[%key:common::config_flow::data::skip_authentication%]",
+          "follow_redirects": "Follow redirects",
           "api_provider": "[%key:common::config_flow::data::api_provider%]"
         }
       }
@@ -145,6 +146,10 @@
         "skip_authentication": {
           "name": "Skip Authentication",
           "description": "Skip authentication."
+        },
+        "follow_redirects": {
+          "name": "Follow redirects",
+          "description": "Follow HTTP 3xx redirects when calling the base URL. Enable when your OpenAI-compatible host (e.g. a proxy or gateway) returns a redirect before reaching the API."
         },
         "api_provider": {
           "name": "API Provider",

--- a/custom_components/extended_openai_conversation/translations/en.json
+++ b/custom_components/extended_openai_conversation/translations/en.json
@@ -14,6 +14,7 @@
                     "api_version": "Api Version",
                     "organization": "Organization",
                     "skip_authentication": "Skip Authentication",
+                    "follow_redirects": "Follow redirects",
                     "api_provider": "Api Provider"
                 }
             }
@@ -145,6 +146,10 @@
                 "skip_authentication": {
                     "name": "Skip Authentication",
                     "description": "Skip authentication."
+                },
+                "follow_redirects": {
+                    "name": "Follow redirects",
+                    "description": "Follow HTTP 3xx redirects when calling the base URL. Enable when your OpenAI-compatible host (e.g. a proxy or gateway) returns a redirect before reaching the API."
                 },
                 "api_provider": {
                     "name": "Api Provider",

--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -23,6 +23,30 @@ Configure Extended OpenAI Conversation through the Options menu in your Voice As
   <img width="400" alt="Edit Assist" src="https://github.com/jekalmin/extended_openai_conversation/assets/2917984/bb394cd4-5790-4ac9-9311-dbcab0fcca56" />
 </Frame>
 
+## Connection settings
+
+Connection settings (API key, base URL, and similar) live on the main integration entry, not the per-assistant Options menu. To change them, go to **Settings** > **Devices & Services**, open **Extended OpenAI Conversation**, and click **Configure**.
+
+<AccordionGroup>
+  <Accordion title="Follow redirects">
+    **Type**: Boolean
+
+    **Default**: `false`
+
+    Follow HTTP `3xx` redirects when calling the base URL.
+
+    Enable this when your OpenAI-compatible host (for example a reverse proxy, gateway, or SSO front-end) returns a redirect before reaching the API. When disabled, the integration surfaces the redirect response as an error such as:
+
+    ```
+    Sorry, I had a problem talking to OpenAI: <html><body>You are being redirected.</body></html>
+    ```
+
+    <Note>
+    Home Assistant's shared HTTP client does not follow redirects by default, while the OpenAI SDK's default client does. Enable this option to follow redirects for your custom host.
+    </Note>
+  </Accordion>
+</AccordionGroup>
+
 ## Configuration Options
 
 ### Options

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,90 @@
+"""Tests for helper functions."""
+
+from unittest.mock import MagicMock, patch
+
+from custom_components.extended_openai_conversation import helpers
+
+
+class TestGetAuthenticatedClient:
+    """Test get_authenticated_client http client selection."""
+
+    async def test_follow_redirects_uses_dedicated_client(self, hass):
+        """When enabled, a redirect-following httpx client is passed to the SDK."""
+        redirect_client = MagicMock(name="redirect_client")
+        shared_client = MagicMock(name="shared_client")
+
+        with (
+            patch.object(
+                helpers, "create_async_httpx_client", return_value=redirect_client
+            ) as mock_create,
+            patch.object(
+                helpers, "get_async_client", return_value=shared_client
+            ) as mock_get,
+            patch.object(helpers, "AsyncOpenAI") as mock_openai,
+        ):
+            await helpers.get_authenticated_client(
+                hass=hass,
+                api_key="test-key",
+                base_url="https://example.com/v1",
+                api_version=None,
+                organization=None,
+                api_provider="openai",
+                skip_authentication=True,
+                follow_redirects=True,
+            )
+
+        mock_create.assert_called_once_with(hass, follow_redirects=True)
+        mock_get.assert_not_called()
+        assert mock_openai.call_args.kwargs["http_client"] is redirect_client
+
+    async def test_default_reuses_shared_client(self, hass):
+        """By default, the HA shared httpx client (no redirects) is reused."""
+        redirect_client = MagicMock(name="redirect_client")
+        shared_client = MagicMock(name="shared_client")
+
+        with (
+            patch.object(
+                helpers, "create_async_httpx_client", return_value=redirect_client
+            ) as mock_create,
+            patch.object(
+                helpers, "get_async_client", return_value=shared_client
+            ) as mock_get,
+            patch.object(helpers, "AsyncOpenAI") as mock_openai,
+        ):
+            await helpers.get_authenticated_client(
+                hass=hass,
+                api_key="test-key",
+                base_url="https://example.com/v1",
+                api_version=None,
+                organization=None,
+                api_provider="openai",
+                skip_authentication=True,
+            )
+
+        mock_get.assert_called_once_with(hass)
+        mock_create.assert_not_called()
+        assert mock_openai.call_args.kwargs["http_client"] is shared_client
+
+    async def test_follow_redirects_applies_to_azure_client(self, hass):
+        """The flag also applies to the Azure client branch."""
+        redirect_client = MagicMock(name="redirect_client")
+
+        with (
+            patch.object(
+                helpers, "create_async_httpx_client", return_value=redirect_client
+            ) as mock_create,
+            patch.object(helpers, "AsyncAzureOpenAI") as mock_azure,
+        ):
+            await helpers.get_authenticated_client(
+                hass=hass,
+                api_key="test-key",
+                base_url="https://example.openai.azure.com",
+                api_version="2024-02-01",
+                organization=None,
+                api_provider="azure",
+                skip_authentication=True,
+                follow_redirects=True,
+            )
+
+        mock_create.assert_called_once_with(hass, follow_redirects=True)
+        assert mock_azure.call_args.kwargs["http_client"] is redirect_client


### PR DESCRIPTION
First off, thanks for maintaining this integration — what drew me to it is the ability to point it at any OpenAI-compatible host (TheGrid.ai, homelab gateways, etc.) rather than being locked to OpenAI/OpenRouter. 
Small opt-in contribution back; happy to iterate on feedback.

## Summary

Adds an opt-in **Follow redirects** flag to the integration's connection
settings so users behind a reverse proxy, gateway, or SSO front-end can
talk to OpenAI-compatible hosts that issue an HTTP `3xx` before reaching
the actual API.

Discovered while testing this integration with [TheGrid.ai](https://app.thegrid.ai), which performs a 307 redirect (within the same host)

## Problem

Home Assistant's shared httpx client (`get_async_client`) disables redirect
following by default (`follow_redirects=False`), whereas the OpenAI SDK's
own default client follows redirects. Because this integration reuses HA's
shared client, any host that responds with a redirect surfaces the redirect
body as a connection error instead of following it:

<img width="563" height="589" alt="Screenshot 2026-06-25 at 12 54 30" src="https://github.com/user-attachments/assets/1673a0c0-b5b0-4395-b30d-2ed1e2a682ea" />

## Solution

- Add `CONF_FOLLOW_REDIRECTS` / `DEFAULT_FOLLOW_REDIRECTS` (default `False`).
- When enabled, `get_authenticated_client` builds the client with
  `create_async_httpx_client(hass, follow_redirects=True)` instead of
  `get_async_client(hass)`. This keeps HA's shared client lifecycle
  (automatic cleanup) while opting into redirect following. Applies to both
  the Azure and non-Azure branches.
- Thread the flag through `__init__.py` (entry data) and `config_flow.py`
  (user step), and allow updating it at runtime via the `change_config`
  service.
- Surface the flag in the UI (`strings.json`, `translations/en.json`,
  `services.yaml`) and document it in `docs/configuration.mdx`.

**Default is OFF**, so existing users see no behavioral change — this is
purely opt-in.

## Testing

- `tests/test_helpers.py` covers the enabled path, the default (shared
  client) path, and the Azure branch, asserting the correct http client is
  passed to the SDK constructor.
- `ruff check` / `ruff format --check` clean.
- `pytest tests/` passes.

> Note: `mypy` reports one pre-existing error in `helpers.py`
> (`Template` with a nullable `hass` argument) that is unrelated to this
> change and present on `develop`.

## How to use

Enable **Settings → Devices & Services → Extended OpenAI Conversation →
Configure → Follow redirects**, or set it at runtime via the
`change_config` service.

<img width="562" height="821" alt="Screenshot 2026-06-25 at 14 02 46" src="https://github.com/user-attachments/assets/970490b3-11cb-4b24-98b0-6f2f02a5e9e7" />

<img width="562" height="575" alt="Screenshot 2026-06-25 at 12 17 38" src="https://github.com/user-attachments/assets/c553e69e-6e6e-4283-9567-7ab93c6644ae" />


