### PR TITLE
Add native file I/O and calculator functions (rebase of #280 onto current main)

### DIFF
--- a/custom_components/extended_openai_conversation/const.py
+++ b/custom_components/extended_openai_conversation/const.py
@@ -105,3 +105,4 @@ DEFAULT_CONTEXT_TRUNCATE_STRATEGY = CONTEXT_TRUNCATE_STRATEGIES[0]["key"]
 SERVICE_QUERY_IMAGE = "query_image"
 
 CONF_PAYLOAD_TEMPLATE = "payload_template"
+DATA_FOLDER = "/config/extended_openai_conversation/"

--- a/custom_components/extended_openai_conversation/helpers.py
+++ b/custom_components/extended_openai_conversation/helpers.py
@@ -39,7 +39,7 @@ from homeassistant.const import (
     CONF_TIMEOUT,
     CONF_VALUE_TEMPLATE,
     CONF_VERIFY_SSL,
-    SERVICE_RELOAD,
+    SERVICE_RELOAD
 )
 from homeassistant.core import HomeAssistant, State
 from homeassistant.exceptions import HomeAssistantError, ServiceNotFound
@@ -49,7 +49,12 @@ from homeassistant.helpers.script import Script
 from homeassistant.helpers.template import Template
 import homeassistant.util.dt as dt_util
 
-from .const import CONF_PAYLOAD_TEMPLATE, DOMAIN, EVENT_AUTOMATION_REGISTERED
+from .const import (
+    CONF_PAYLOAD_TEMPLATE, 
+    DOMAIN, 
+    EVENT_AUTOMATION_REGISTERED,
+    DATA_FOLDER
+)
 from .exceptions import (
     CallServiceError,
     EntityNotExposed,
@@ -447,7 +452,9 @@ class NativeFunctionExecutor(FunctionExecutor):
             raise ValueError(f"Invalid open mode '{open_mode}'. Allowed modes are: {', '.join(allowed_modes)}")
             
         try:
-            full_path = os.path.abspath(filename)
+            os.makedirs(DATA_FOLDER, exist_ok=True)
+            safe_filename = os.path.basename(filename)
+            full_path = os.path.join(DATA_FOLDER, safe_filename)
             _LOGGER.info("Writing to file: %s, open_mode: %s, content: %s", full_path, open_mode, content)
             async with aiofiles.open(full_path, open_mode) as f:
                 await f.write(content)
@@ -467,7 +474,9 @@ class NativeFunctionExecutor(FunctionExecutor):
     ):
         """Read content from a file asynchronously."""
         filename = arguments["filename"]
-        full_path = os.path.abspath(filename)
+        os.makedirs(DATA_FOLDER, exist_ok=True)
+        safe_filename = os.path.basename(filename)
+        full_path = os.path.join(DATA_FOLDER, safe_filename)
         _LOGGER.info("Reading from file: %s", full_path)
         async with aiofiles.open(full_path, "r") as f:
             content = await f.read()
@@ -489,8 +498,8 @@ class NativeFunctionExecutor(FunctionExecutor):
             return state.as_dict()
         return state
 
-    def calculate(self, hass: HomeAssistant, function, arguments, user_input: conversation.ConversationInput, exposed_entities):
-        expression = function["expression"]
+    async def calculate(self, hass: HomeAssistant, function, arguments, user_input: conversation.ConversationInput, exposed_entities):
+        expression = arguments["expression"]
         try:
             if not self.is_math_expr(expression):
                 raise HomeAssistantError("Expression is not a valid mathematical expression.")

--- a/custom_components/extended_openai_conversation/helpers.py
+++ b/custom_components/extended_openai_conversation/helpers.py
@@ -426,6 +426,25 @@ class NativeFunctionExecutor(FunctionExecutor):
             arguments.get("types", {"change"}),
         )
 
+    def _resolve_data_path(self, filename: str) -> str:
+        """Resolve filename to an absolute path confined to DATA_FOLDER.
+
+        os.path.basename() alone lets filename=".." slip through unchanged
+        (no separator to strip), escaping DATA_FOLDER by one directory level.
+        Resolving the real path and checking containment closes that gap.
+        """
+        safe_filename = os.path.basename(filename)
+        full_path = os.path.join(DATA_FOLDER, safe_filename)
+        resolved_path = os.path.realpath(full_path)
+        resolved_data_folder = os.path.realpath(DATA_FOLDER)
+        if resolved_path != resolved_data_folder and not resolved_path.startswith(
+            resolved_data_folder + os.sep
+        ):
+            raise HomeAssistantError(
+                f"Invalid filename '{filename}': resolves outside the data folder"
+            )
+        return resolved_path
+
     async def write_to_file(
         self,
         hass: HomeAssistant,
@@ -453,8 +472,7 @@ class NativeFunctionExecutor(FunctionExecutor):
             
         try:
             os.makedirs(DATA_FOLDER, exist_ok=True)
-            safe_filename = os.path.basename(filename)
-            full_path = os.path.join(DATA_FOLDER, safe_filename)
+            full_path = self._resolve_data_path(filename)
             _LOGGER.info("Writing to file: %s, open_mode: %s, content: %s", full_path, open_mode, content)
             async with aiofiles.open(full_path, open_mode) as f:
                 await f.write(content)
@@ -477,8 +495,7 @@ class NativeFunctionExecutor(FunctionExecutor):
         filename = arguments["filename"]
         try:
             os.makedirs(DATA_FOLDER, exist_ok=True)
-            safe_filename = os.path.basename(filename)
-            full_path = os.path.join(DATA_FOLDER, safe_filename)
+            full_path = self._resolve_data_path(filename)
             _LOGGER.info("Reading from file: %s", full_path)
             async with aiofiles.open(full_path, "r") as f:
                 content = await f.read()

--- a/custom_components/extended_openai_conversation/helpers.py
+++ b/custom_components/extended_openai_conversation/helpers.py
@@ -8,6 +8,7 @@ import os
 import re
 import sqlite3
 import time
+import aiofiles
 from typing import Any
 from urllib import parse
 
@@ -207,6 +208,17 @@ class NativeFunctionExecutor(FunctionExecutor):
     def __init__(self) -> None:
         """initialize native function"""
         super().__init__(vol.Schema({vol.Required("name"): str}))
+        self.native_functions = {
+            "execute_service": self.execute_service,
+            "execute_service_single": self.execute_service_single,
+            "add_automation": self.add_automation,
+            "get_history": self.get_history,
+            "get_energy": self.get_energy,
+            "get_statistics": self.get_statistics,
+            "get_user_from_user_id": self.get_user_from_user_id,
+            "write_to_file": self.write_to_file,
+            "read_from_file": self.read_from_file
+        }
 
     async def execute(
         self,
@@ -217,36 +229,15 @@ class NativeFunctionExecutor(FunctionExecutor):
         exposed_entities,
     ):
         name = function["name"]
-        if name == "execute_service":
-            return await self.execute_service(
-                hass, function, arguments, user_input, exposed_entities
-            )
-        if name == "execute_service_single":
-            return await self.execute_service_single(
-                hass, function, arguments, user_input, exposed_entities
-            )
-        if name == "add_automation":
-            return await self.add_automation(
-                hass, function, arguments, user_input, exposed_entities
-            )
-        if name == "get_history":
-            return await self.get_history(
-                hass, function, arguments, user_input, exposed_entities
-            )
-        if name == "get_energy":
-            return await self.get_energy(
-                hass, function, arguments, user_input, exposed_entities
-            )
-        if name == "get_statistics":
-            return await self.get_statistics(
-                hass, function, arguments, user_input, exposed_entities
-            )
-        if name == "get_user_from_user_id":
-            return await self.get_user_from_user_id(
-                hass, function, arguments, user_input, exposed_entities
-            )
 
-        raise NativeNotFound(name)
+        native_function = self.native_functions.get(name)
+        if not native_function:
+            raise NativeNotFound(name)
+
+        result = await native_function(
+            hass, function, arguments, user_input, exposed_entities
+        )
+        return result
 
     async def execute_service_single(
         self,
@@ -428,6 +419,59 @@ class NativeFunctionExecutor(FunctionExecutor):
             arguments.get("types", {"change"}),
         )
 
+    async def write_to_file(
+        self,
+        hass: HomeAssistant,
+        function,
+        arguments,
+        user_input: conversation.ConversationInput,
+        exposed_entities,
+    ):
+        """Write content to a file asynchronously.
+        
+        Args:
+            arguments: Dictionary containing:
+                filename: Path to the file
+                content: Content to write
+                open_mode: Optional file mode ('w', 'a', 'w+', 'a+'). Defaults to 'w'
+        """
+        filename = arguments["filename"]
+        content = arguments["content"]
+        open_mode = arguments.get("open_mode", "w")
+        
+        # Validate file mode for safety
+        allowed_modes = {"w", "a", "w+", "a+"}
+        if open_mode not in allowed_modes:
+            raise ValueError(f"Invalid open mode '{open_mode}'. Allowed modes are: {', '.join(allowed_modes)}")
+            
+        try:
+            full_path = os.path.abspath(filename)
+            _LOGGER.info("Writing to file: %s, open_mode: %s, content: %s", full_path, open_mode, content)
+            async with aiofiles.open(full_path, open_mode) as f:
+                await f.write(content)
+            return "Success"
+        except (IOError, OSError) as e:
+            error_msg = f"Failed to write to file {full_path}: {str(e)}"
+            _LOGGER.error(error_msg)
+            raise HomeAssistantError(error_msg) from e
+
+    async def read_from_file(
+        self,
+        hass: HomeAssistant,
+        function,
+        arguments,
+        user_input: conversation.ConversationInput,
+        exposed_entities,
+    ):
+        """Read content from a file asynchronously."""
+        filename = arguments["filename"]
+        full_path = os.path.abspath(filename)
+        _LOGGER.info("Reading from file: %s", full_path)
+        async with aiofiles.open(full_path, "r") as f:
+            content = await f.read()
+        _LOGGER.info("File content: %s", content)
+        return content
+
     def as_utc(self, value: str, default_value, parse_error_message: str):
         if value is None:
             return default_value
@@ -442,8 +486,7 @@ class NativeFunctionExecutor(FunctionExecutor):
         if isinstance(state, State):
             return state.as_dict()
         return state
-
-
+    
 class ScriptFunctionExecutor(FunctionExecutor):
     def __init__(self) -> None:
         """initialize script function"""
@@ -754,7 +797,6 @@ class SqliteFunctionExecutor(FunctionExecutor):
             for row in rows:
                 result.append({name: val for name, val in zip(names, row)})
             return result
-
 
 FUNCTION_EXECUTORS: dict[str, FunctionExecutor] = {
     "native": NativeFunctionExecutor(),

--- a/custom_components/extended_openai_conversation/helpers.py
+++ b/custom_components/extended_openai_conversation/helpers.py
@@ -39,7 +39,7 @@ from homeassistant.const import (
     CONF_TIMEOUT,
     CONF_VALUE_TEMPLATE,
     CONF_VERIFY_SSL,
-    SERVICE_RELOAD
+    SERVICE_RELOAD,
 )
 from homeassistant.core import HomeAssistant, State
 from homeassistant.exceptions import HomeAssistantError, ServiceNotFound
@@ -53,7 +53,7 @@ from .const import (
     CONF_PAYLOAD_TEMPLATE, 
     DOMAIN, 
     EVENT_AUTOMATION_REGISTERED,
-    DATA_FOLDER
+    DATA_FOLDER,
 )
 from .exceptions import (
     CallServiceError,

--- a/custom_components/extended_openai_conversation/helpers.py
+++ b/custom_components/extended_openai_conversation/helpers.py
@@ -3,6 +3,7 @@
 from abc import ABC, abstractmethod
 from datetime import timedelta
 from functools import partial
+import ast
 import logging
 import os
 import re
@@ -217,7 +218,8 @@ class NativeFunctionExecutor(FunctionExecutor):
             "get_statistics": self.get_statistics,
             "get_user_from_user_id": self.get_user_from_user_id,
             "write_to_file": self.write_to_file,
-            "read_from_file": self.read_from_file
+            "read_from_file": self.read_from_file,
+            "calculate": self.calculate
         }
 
     async def execute(
@@ -486,7 +488,38 @@ class NativeFunctionExecutor(FunctionExecutor):
         if isinstance(state, State):
             return state.as_dict()
         return state
-    
+
+    def calculate(self, hass: HomeAssistant, function, arguments, user_input: conversation.ConversationInput, exposed_entities):
+        expression = function["expression"]
+        try:
+            if not self.is_math_expr(expression):
+                raise HomeAssistantError("Expression is not a valid mathematical expression.")
+            result = eval(expression)
+            return result
+        except Exception as e:
+            raise HomeAssistantError(f"Error evaluating math expression: {str(e)}")
+
+    def is_math_expr(self, expr):
+        """
+        Determines if a given Python expression is a mathematical expression.
+
+        Args:
+            expr (str): The input expression as a string.
+
+        Returns:
+            bool: True if the expression is mathematical, False otherwise.
+        """
+        allowed_node_types = (
+            ast.Expression, ast.BinOp, ast.UnaryOp, ast.Module, ast.Constant,
+            ast.Add, ast.Sub, ast.Mult, ast.Div, ast.Pow, ast.Mod, ast.USub 
+            )
+
+        try:
+            tree = ast.parse(expr, mode='eval')
+            return all(isinstance(x, allowed_node_types) for x in ast.walk(tree))
+        except Exception: 
+            return False
+
 class ScriptFunctionExecutor(FunctionExecutor):
     def __init__(self) -> None:
         """initialize script function"""

--- a/custom_components/extended_openai_conversation/helpers.py
+++ b/custom_components/extended_openai_conversation/helpers.py
@@ -460,7 +460,7 @@ class NativeFunctionExecutor(FunctionExecutor):
                 await f.write(content)
             return "Success"
         except (IOError, OSError) as e:
-            error_msg = f"Failed to write to file {full_path}: {str(e)}"
+            error_msg = f"Error encountered while writing to file {full_path}: {str(e)}"
             _LOGGER.error(error_msg)
             raise HomeAssistantError(error_msg) from e
 
@@ -473,13 +473,22 @@ class NativeFunctionExecutor(FunctionExecutor):
         exposed_entities,
     ):
         """Read content from a file asynchronously."""
+
         filename = arguments["filename"]
-        os.makedirs(DATA_FOLDER, exist_ok=True)
-        safe_filename = os.path.basename(filename)
-        full_path = os.path.join(DATA_FOLDER, safe_filename)
-        _LOGGER.info("Reading from file: %s", full_path)
-        async with aiofiles.open(full_path, "r") as f:
-            content = await f.read()
+        try:
+            os.makedirs(DATA_FOLDER, exist_ok=True)
+            safe_filename = os.path.basename(filename)
+            full_path = os.path.join(DATA_FOLDER, safe_filename)
+            _LOGGER.info("Reading from file: %s", full_path)
+            async with aiofiles.open(full_path, "r") as f:
+                content = await f.read()
+        except FileNotFoundError:
+            _LOGGER.warning("File not found: %s. Returning empty string.", full_path)
+            content = ""
+        except (IOError, OSError) as e:
+            error_msg = f"Error encountered while reading from file {full_path}: {str(e)}"
+            _LOGGER.error(error_msg)
+            raise HomeAssistantError(error_msg) from e
         _LOGGER.info("File content: %s", content)
         return content
 

--- a/custom_components/extended_openai_conversation/manifest.json
+++ b/custom_components/extended_openai_conversation/manifest.json
@@ -18,7 +18,8 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/jekalmin/extended_openai_conversation/issues",
   "requirements": [
-    "openai~=2.21.0"
+    "openai~=2.21.0",
+    "aiofiles>=24.1.0"
   ],
   "version": "2.0.2"
 }

--- a/examples/calculator/README.md
+++ b/examples/calculator/README.md
@@ -1,0 +1,60 @@
+## Objective
+- Calculate a simple math expression and return the calculation result as a number.
+
+
+## Functions
+
+### write_to_file
+```yaml
+- spec:
+    name: calculate
+    description: calculate a math expression and return the calculation result as a number.
+    strict: true
+    parameters:
+      type: object
+      additionalProperties: false
+      properties:
+        expression:
+          type: string
+          description: a legal Python expression that contains only common math operators (+, -, *, /, **, %), numbers, and brackets.
+      required:
+        - expression
+  function:
+    type: native
+    name: calculate
+```
+
+## Example
+### Prompt
+...
+When the inquiry implies math calculation (e.g., "how much in total did I make over the past week?"), always call function calculate to get the result. You can do that by formulate the calculation as a Python math expression and evaluate it by calling function "calculate". Do not ask user to confirm if calculation is needed.
+```
+### Sample Conversation 1
+```
+User:
+What's 247 divided by 4, and then powered by 5?
+
+Assistant:
+The result of 247 divided by 4, and then raised to the power of 5, is approximately 897,810,767.58.
+```
+
+### Sample Conversation 2
+```
+User:
+How much milk did the baby drink today?
+
+Assistant:
+I found the following entries in the memo regarding how much the baby drank today:
+
+- 130 ml at 00:30
+- 125 ml at 05:00
+- 110 ml at 13:00
+- 125 ml at 06:00
+- 130 ml at 21:00
+
+I added these amounts together:
+
+130 + 125 + 110 + 125 + 130 = 620 ml.
+
+That's how I reached the total of 620 milliliters.
+```

--- a/examples/function/file operations/README.md
+++ b/examples/function/file operations/README.md
@@ -1,0 +1,61 @@
+## Objective
+- Use file read/write functions to implement features such as persistent memory.
+
+
+## Functions
+
+### write_to_file
+```yaml
+- spec:
+    name: write_to_file
+    description: write the provided content to the specified file. A new file will be created if one does not exist. 
+    parameters:
+      type: object
+      properties:
+        filename:
+          type: string
+          description: a filename consists of 2-32 alphanumerical characters and underscore.
+        content:
+          type: string
+          description: the content to be written.
+        open_mode:
+          type: string
+          description: optional file mode ('w', 'a', 'w+', 'a+'). Defaults to 'w'
+        required:
+        - filename
+        - content
+  function:
+    type: native
+    name: write_to_file
+```
+
+### read_from_file
+```yaml
+- spec:
+    name: read_from_file
+    description: read text from the specified file.
+    parameters:
+      type: object
+      properties:
+        filename:
+          type: string
+          description: a filename consists of 2-32 alphanumerical characters.
+        required:
+        - filename
+  function:
+    type: native
+    name: read_from_file
+```
+
+## Sample prompts
+```
+When explicitly requested, help user remember things by appending a new row (fields "timestamp" and "content") using write_to_file function to the file "assistant_memo.csv". Retrieve later by reading from one or more files with the read_from_file function. 
+
+Example: 
+User: help me remember that I have taken vitamin today.
+(You should call function write_to_file("assistant_memo.csv", "2024-12-28 08:00:05.109809-08:00,\"user has taken vitamin today\"\n", "a")
+User: help me remember that I just took vitamin.
+(You should call function write_to_file("assistant_memo.csv", "2024-12-28 21:57:01.103210-08:00,\"user just took vitamin\"\n", "a")
+User: how many times have I taken vitamin today?
+You: Yes, you have taken Vitamin twice today at 8:00 and 21:57 respectively.
+```


### PR DESCRIPTION
This rebases @lifuhuang's file I/O + calculator work from #280 onto the current `main` branch, since that PR has drifted out of sync with `main` and looks stuck.

All credit for the actual feature work goes to @lifuhuang — the first five commits here are his, cherry-picked with original authorship preserved:
- Support basic file operations for long-term memory.
- Support calculator.
- Restrict file access to predefined data folder.
- handle FileNotFoundError when reading.
- Fix typos.

On top of that I added one small fix: `os.path.basename()` alone doesn't strip a bare `..`, so `filename=".."` escaped the intended data folder by one directory level (exposing files immediately above `DATA_FOLDER`, e.g. `configuration.yaml`). The added commit resolves the real path and verifies it stays inside `DATA_FOLDER` before use.

Tested locally: file write/read round-trip, the `..` case is now rejected, and the calculator still returns correct results.

Posting this as a separate PR (rather than pushing to #280 directly) since I don't have write access to that branch — happy to close this in favor of #280 if @lifuhuang would rather update it there instead.
