### PR TITLE
fix: always include content key on assistant messages with tool_calls

### DIFF
--- a/custom_components/extended_openai_conversation/entity.py
+++ b/custom_components/extended_openai_conversation/entity.py
@@ -142,6 +142,10 @@ def _convert_content_to_param(
             # Remove tool_calls field if it's an empty array to maintain compatibility
             if msg.get("tool_calls") == []:
                 msg.pop("tool_calls", None)
+            # Some OpenAI-compatible APIs (vLLM, SGLang, etc.) reject assistant
+            # messages missing the "content" key entirely; ensure it's always present
+            if "content" not in msg:
+                msg["content"] = None
             messages.append(msg)
         elif content.role == "tool_result":
             messages.append(

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -1,0 +1,40 @@
+"""Tests for entity.py message serialization helpers."""
+
+from custom_components.extended_openai_conversation.entity import (
+    _convert_content_to_param,
+)
+from homeassistant.components import conversation
+from homeassistant.helpers import llm
+
+
+def test_assistant_tool_call_without_text_has_content_key():
+    """Assistant messages with tool_calls but no text must still include "content"."""
+    content = conversation.AssistantContent(
+        agent_id="test_agent",
+        content=None,
+        tool_calls=[
+            llm.ToolInput(
+                id="call_1",
+                tool_name="turn_on_light",
+                tool_args={"entity_id": "light.living_room"},
+            )
+        ],
+    )
+
+    messages = _convert_content_to_param([content])
+
+    assert len(messages) == 1
+    assert messages[0]["content"] is None
+
+
+def test_assistant_text_only_content_unchanged():
+    """Assistant messages that already carry text keep their content unchanged."""
+    content = conversation.AssistantContent(
+        agent_id="test_agent",
+        content="Hello there",
+    )
+
+    messages = _convert_content_to_param([content])
+
+    assert len(messages) == 1
+    assert messages[0]["content"] == "Hello there"


### PR DESCRIPTION
Some OpenAI-compatible endpoints (vLLM, SGLang, Qwen servers, gateways) reject assistant messages that omit the "content" key entirely, which happened whenever a message had tool_calls but no text. Default it to None (JSON null) so it's always present, matching the existing Mistral empty-tool_calls compatibility guard.