### PR TITLE
fix: detect Chinese follow-up questions for continued conversation

### DIFF
--- a/custom_components/extended_openai_conversation/conversation.py
+++ b/custom_components/extended_openai_conversation/conversation.py
@@ -72,6 +72,44 @@ from .helpers import get_function_executor
 
 _LOGGER = logging.getLogger(__name__)
 
+# Phrases that indicate the LLM is asking a follow-up question and the
+# conversation should continue listening. Keep entries lowercase.
+FOLLOW_UP_PHRASES = [
+    "which one",
+    "would you like",
+    "do you want",
+    "would you prefer",
+    "which do you",
+    "what would you",
+    "shall i",
+    "should i",
+    "choose from",
+    "select from",
+    "pick from",
+    # Chinese follow-up question patterns
+    "哪个",
+    "哪些",
+    "哪台",
+    "哪种",
+    "要不要",
+    "想让我",
+    "要我帮",
+    "你需要",
+    "你想",
+    "你要",
+    "还是",
+]
+
+# Question marks that end a follow-up question (ASCII and full-width CJK).
+FOLLOW_UP_QUESTION_MARKS = ("?", "？")
+
+
+def _is_follow_up_question(text: str) -> bool:
+    """Detect if the LLM response asks a follow-up question."""
+    return text.rstrip().endswith(FOLLOW_UP_QUESTION_MARKS) or any(
+        phrase in text.lower() for phrase in FOLLOW_UP_PHRASES
+    )
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -214,23 +252,7 @@ class ExtendedOpenAIAgentEntity(
         intent_response.async_set_speech(query_response.message.content)
 
         # Detect if LLM is asking a follow-up question to enable continued conversation
-        response_text = query_response.message.content or ""
-        should_continue = response_text.rstrip().endswith("?") or any(
-            phrase in response_text.lower()
-            for phrase in [
-                "which one",
-                "would you like",
-                "do you want",
-                "would you prefer",
-                "which do you",
-                "what would you",
-                "shall i",
-                "should i",
-                "choose from",
-                "select from",
-                "pick from",
-            ]
-        )
+        should_continue = _is_follow_up_question(query_response.message.content or "")
 
         return conversation.ConversationResult(
             response=intent_response,

--- a/tests/test_conversation.py
+++ b/tests/test_conversation.py
@@ -1,0 +1,55 @@
+"""Tests for follow-up question detection in conversation.py."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from custom_components.extended_openai_conversation.conversation import (
+    _is_follow_up_question,
+)
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        # English questions ending with ASCII question mark
+        "Which light would you like to turn on?",
+        "Do you want me to continue ? ",
+        # English follow-up phrases without question mark
+        "Which one should I control",
+        "Would you like me to turn it on",
+        # Chinese questions ending with full-width question mark
+        "你想让我帮你控制家里的哪个设备呢？",
+        "好的，是要打开客厅的灯带吗？",
+        "请问需要调节到多少度？ ",
+        # Chinese follow-up phrases without question mark
+        "你想打开哪个房间的灯",
+        "你要开灯还是关灯",
+        "要不要我帮你关掉",
+        "你需要我做什么",
+        "想让我调到多少度",
+    ],
+)
+def test_follow_up_question_detected(text: str) -> None:
+    """Follow-up questions are detected in English and Chinese."""
+    assert _is_follow_up_question(text) is True
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        # Plain statements
+        "好的，已经帮你打开客厅的灯。",
+        "The living room light is now on.",
+        "现在是晚上 11 点 46 分。",
+        # Empty / whitespace
+        "",
+        "   ",
+    ],
+)
+def test_statement_not_detected(text: str) -> None:
+    """Plain statements do not trigger continued conversation."""
+    assert _is_follow_up_question(text) is False


### PR DESCRIPTION
## Problem

On the 2.0.x line, `_async_handle_message` decides `continue_conversation` by checking whether the LLM response ends with an ASCII `?` or contains a small set of English follow-up phrases.

When the agent replies in Chinese, a follow-up question like `你想让我帮你控制家里的哪个设备呢？` ends with a full-width question mark `？` and is **not** detected. The pipeline then returns `continue_conversation: false`, so Assist satellites (which support `START_CONVERSATION`) stop listening instead of waiting for the user's answer — the user has to re-trigger the wake word for every follow-up.

## Change

- Accept the full-width question mark `？` in addition to ASCII `?`
- Add common Chinese follow-up phrases (`哪个` / `哪些` / `哪台` / `哪种` / `要不要` / `想让我` / `要我帮` / `你需要` / `你想` / `你要` / `还是`) to the phrase list
- Factor the heuristic into a module-level `_is_follow_up_question()` helper with `FOLLOW_UP_PHRASES` / `FOLLOW_UP_QUESTION_MARKS` constants so it can be unit tested
- Add `tests/test_conversation.py` covering English/Chinese questions and plain statements

No behavior change for English responses.

## Notes

- `develop` (3.0) is unaffected: it uses `chat_log.continue_conversation` from HA core instead of this heuristic, so this targets `main` (2.0.x) only.
- Verified on a live Home Assistant 2026.7 instance running 2.0.2: after the patch, a Chinese follow-up question returns `continue_conversation: true` via `conversation.process`, and the satellite keeps listening for the answer.

## Testing

```
pytest tests/test_conversation.py -v
17 passed
```