### PR TITLE
Declare voluptuous-openapi requirement

### DIFF
--- a/custom_components/extended_openai_conversation/manifest.json
+++ b/custom_components/extended_openai_conversation/manifest.json
@@ -19,7 +19,8 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/jekalmin/extended_openai_conversation/issues",
   "requirements": [
-    "openai>=2.21.0"
+    "openai>=2.21.0",
+    "voluptuous-openapi>=0.4.1"
   ],
   "version": "3.0.0"
 }

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -17,6 +17,8 @@ pytest-homeassistant-custom-component>=0.12.0
 
 # Schema validation
 voluptuous>=0.13.0
+# Not provided by HA core since 2026.9 (core switched to probatio.to_openapi)
+voluptuous-openapi>=0.4.1
 
 # YAML parsing
 PyYAML>=6.0


### PR DESCRIPTION
setup is broken on HA 2026.9. What you see is:

```
ModuleNotFoundError: Platform extended_openai_conversation.ai_task not found
```

but the error that actually broke it is a bit earlier in the log:

```
  File "/config/custom_components/extended_openai_conversation/ai_task.py", line 16, in <module>
    from .entity import ExtendedOpenAIBaseLLMEntity
  File "/config/custom_components/extended_openai_conversation/entity.py", line 19, in <module>
    from voluptuous_openapi import convert
ModuleNotFoundError: No module named 'voluptuous_openapi'
```

core stopped shipping voluptuous-openapi in 2026.9 (they use probatio for this now), so that import fails, and since HA caches the platform as missing every attempt after that one complains about ai_task.

We only ever had the package through core, so: declare it in the manifest. Same in requirements_test.txt because CI gets these versions from core.

probatio is not a drop in here fwiw, to_openapi does not take voluptuous schemas:

```
>>> to_openapi(vol.Schema({"name": str}))
TypeError: cannot use 'voluptuous.schema_builder.Schema' as a dict key (unhashable type: 'Schema')
```

`structure` is a vol.Schema, so moving off voluptuous is a bigger job than this fix.

closes #464
